### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DINGDANGMAOUP/mihomo-rs/security/code-scanning/2](https://github.com/DINGDANGMAOUP/mihomo-rs/security/code-scanning/2)

The best way to fix this problem is to add an explicit `permissions` block at the workflow (root) level of `.github/workflows/ci.yml`. This will ensure all jobs in the workflow run with minimally necessary privileges for the GITHUB_TOKEN, rather than inheriting possibly excessive repository or organizational defaults. 

Specifically, insert:
```yaml
permissions:
  contents: read
```
after the `name` (line 1) and before the `on` block (line 3). This ensures that all jobs in the workflow only have read access to repository contents by default.

No other changes, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
