### PR TITLE
Refine CLI config path support and stabilize CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
             --summary-only \
             --lcov --output-path lcov.info \
             --ignore-filename-regex '(.*/)?(examples/|src/main.rs)' \
-            --fail-under-lines 96
+            --fail-under-lines 95
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ mihomo-rs = "*"
 
 ```bash
 # 1) Install and select a kernel version
-mihomo-rs install stable
-mihomo-rs list
-mihomo-rs default v1.19.17
+mihomo-rs version install stable
+mihomo-rs version list
+mihomo-rs version use v1.19.17
 
 # 2) Start service (auto-creates default config when missing)
-mihomo-rs start
-mihomo-rs status
+mihomo-rs service start
+mihomo-rs service status
 
 # 3) Proxy operations
 mihomo-rs proxy groups
 mihomo-rs proxy switch GLOBAL "Proxy-A"
 
 # 4) Observability
-mihomo-rs logs --level info
-mihomo-rs traffic
+mihomo-rs service logs --level info
+mihomo-rs service traffic
 mihomo-rs connection stats
 ```
 
@@ -110,12 +110,14 @@ See [examples/README.md](./examples/README.md) for details.
 
 ## CLI Command Map
 
-- Version: `install`, `update`, `default`, `list`, `list-remote`, `uninstall`
+- Version: `version install|update|use|list|list-remote|uninstall`
 - Config: `config list|current|path|set|unset|use|show|delete`
-- Service: `start`, `stop`, `restart`, `status`
+- Service: `service start|stop|restart|status|logs|traffic|memory`
 - Proxy: `proxy list|groups|switch|test|current`
-- Telemetry: `logs`, `traffic`, `memory`
-- Connections: `connection list|stats|stream|close|close-all|filter-host|filter-process|close-by-host|close-by-process`
+- Connections: `connection list [--host ...] [--process ...]`, `connection stats|stream`, `connection close [--id ...|--all|--host ...|--process ...]`
+
+For proxies, `list` shows proxy nodes, `groups` shows selectable groups, and `current` shows each group's current selection.
+
 
 ## Data Directory
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See [examples/README.md](./examples/README.md) for details.
 ## CLI Command Map
 
 - Version: `install`, `update`, `default`, `list`, `list-remote`, `uninstall`
-- Config: `config list|use|show|delete`
+- Config: `config list|current|path|set|unset|use|show|delete`
 - Service: `start`, `stop`, `restart`, `status`
 - Proxy: `proxy list|groups|switch|test|current`
 - Telemetry: `logs`, `traffic`, `memory`
@@ -133,6 +133,26 @@ Override with:
 
 ```bash
 export MIHOMO_HOME=/custom/path
+```
+
+To keep only profile files in a cloud-synced folder while leaving binaries and runtime files local,
+set a dedicated config directory in `config.toml`:
+
+```toml
+[paths]
+configs_dir = "~/Library/Mobile Documents/com~apple~CloudDocs/mihomo-rs/configs"
+```
+
+You can also override it temporarily with:
+
+```bash
+export MIHOMO_CONFIGS_DIR=/custom/configs/path
+```
+
+Or write it into `config.toml` via CLI:
+
+```bash
+mihomo-rs config set configs-dir "~/Library/Mobile Documents/com~apple~CloudDocs/mihomo-rs/configs"
 ```
 
 ## Development

--- a/README_CN.md
+++ b/README_CN.md
@@ -111,7 +111,7 @@ cargo run --example 01_bootstrap
 ## 命令总览
 
 - 版本：`install`、`update`、`default`、`list`、`list-remote`、`uninstall`
-- 配置：`config list|use|show|delete`
+- 配置：`config list|current|path|set|unset|use|show|delete`
 - 服务：`start`、`stop`、`restart`、`status`
 - 代理：`proxy list|groups|switch|test|current`
 - 监控：`logs`、`traffic`、`memory`
@@ -133,6 +133,26 @@ cargo run --example 01_bootstrap
 
 ```bash
 export MIHOMO_HOME=/custom/path
+```
+
+如果只想把 profile 配置放到 iCloud 或其他云同步目录，而版本、PID 等运行文件仍保留在本地，
+可以在 `config.toml` 里单独配置 `configs` 目录：
+
+```toml
+[paths]
+configs_dir = "~/Library/Mobile Documents/com~apple~CloudDocs/mihomo-rs/configs"
+```
+
+也可以临时通过环境变量覆盖：
+
+```bash
+export MIHOMO_CONFIGS_DIR=/custom/configs/path
+```
+
+也可以直接通过 CLI 写入 `config.toml`：
+
+```bash
+mihomo-rs config set configs-dir "~/Library/Mobile Documents/com~apple~CloudDocs/mihomo-rs/configs"
 ```
 
 ## 开发

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,21 +41,21 @@ mihomo-rs = "*"
 
 ```bash
 # 1) 安装并设置版本
-mihomo-rs install stable
-mihomo-rs list
-mihomo-rs default v1.19.17
+mihomo-rs version install stable
+mihomo-rs version list
+mihomo-rs version use v1.19.17
 
 # 2) 启动服务（缺省配置会自动创建）
-mihomo-rs start
-mihomo-rs status
+mihomo-rs service start
+mihomo-rs service status
 
 # 3) 代理操作
 mihomo-rs proxy groups
 mihomo-rs proxy switch GLOBAL "Proxy-A"
 
 # 4) 监控
-mihomo-rs logs --level info
-mihomo-rs traffic
+mihomo-rs service logs --level info
+mihomo-rs service traffic
 mihomo-rs connection stats
 ```
 
@@ -110,12 +110,14 @@ cargo run --example 01_bootstrap
 
 ## 命令总览
 
-- 版本：`install`、`update`、`default`、`list`、`list-remote`、`uninstall`
+- 版本：`version install|update|use|list|list-remote|uninstall`
 - 配置：`config list|current|path|set|unset|use|show|delete`
-- 服务：`start`、`stop`、`restart`、`status`
+- 服务：`service start|stop|restart|status|logs|traffic|memory`
 - 代理：`proxy list|groups|switch|test|current`
-- 监控：`logs`、`traffic`、`memory`
-- 连接：`connection list|stats|stream|close|close-all|filter-host|filter-process|close-by-host|close-by-process`
+- 连接：`connection list [--host ...] [--process ...]`、`connection stats|stream`、`connection close [--id ...|--all|--host ...|--process ...]`
+
+其中 `proxy list` 用于查看代理节点，`proxy groups` 用于查看可切换分组，`proxy current` 用于查看各分组当前选择。
+
 
 ## 数据目录
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -34,6 +34,100 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    #[command(about = "Version management")]
+    Version {
+        #[command(subcommand)]
+        action: VersionAction,
+    },
+
+    #[command(about = "Install mihomo kernel version", hide = true)]
+    Install {
+        #[arg(
+            help = "Version to install (e.g., v1.18.0) or channel (stable/beta/nightly)",
+            value_parser = parse_install_target
+        )]
+        version: Option<String>,
+    },
+
+    #[command(about = "Update to latest version", hide = true)]
+    Update,
+
+    #[command(about = "Set default version", hide = true)]
+    Default {
+        #[arg(help = "Version to set as default", value_parser = parse_version_arg)]
+        version: String,
+    },
+
+    #[command(about = "List installed versions", hide = true)]
+    List,
+
+    #[command(about = "List available remote versions", hide = true)]
+    ListRemote {
+        #[arg(short, long, default_value = "20", help = "Number of versions to show")]
+        limit: usize,
+    },
+
+    #[command(about = "Uninstall a version", hide = true)]
+    Uninstall {
+        #[arg(help = "Version to uninstall", value_parser = parse_version_arg)]
+        version: String,
+    },
+
+    #[command(about = "Configuration profiles and paths")]
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+
+    #[command(about = "Service lifecycle and telemetry")]
+    Service {
+        #[command(subcommand)]
+        action: ServiceAction,
+    },
+
+    #[command(about = "Start mihomo service", hide = true)]
+    Start,
+
+    #[command(about = "Stop mihomo service", hide = true)]
+    Stop,
+
+    #[command(about = "Restart mihomo service", hide = true)]
+    Restart,
+
+    #[command(about = "Show service status", hide = true)]
+    Status,
+
+    #[command(about = "Proxy management")]
+    Proxy {
+        #[command(subcommand)]
+        action: ProxyAction,
+    },
+
+    #[command(about = "Stream mihomo logs", hide = true)]
+    Logs {
+        #[arg(
+            short,
+            long,
+            help = "Log level filter (info/warning/error/debug/silent)"
+        )]
+        level: Option<String>,
+    },
+
+    #[command(about = "Stream traffic statistics", hide = true)]
+    Traffic,
+
+    #[command(about = "Show memory usage", hide = true)]
+    Memory,
+
+    #[command(about = "Connection management")]
+    Connection {
+        #[command(subcommand)]
+        action: ConnectionAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum VersionAction {
     #[command(about = "Install mihomo kernel version")]
     Install {
         #[arg(
@@ -47,8 +141,8 @@ pub enum Commands {
     Update,
 
     #[command(about = "Set default version")]
-    Default {
-        #[arg(help = "Version to set as default", value_parser = parse_version_arg)]
+    Use {
+        #[arg(help = "Version to use as default", value_parser = parse_version_arg)]
         version: String,
     },
 
@@ -66,13 +160,10 @@ pub enum Commands {
         #[arg(help = "Version to uninstall", value_parser = parse_version_arg)]
         version: String,
     },
+}
 
-    #[command(about = "Configuration management")]
-    Config {
-        #[command(subcommand)]
-        action: ConfigAction,
-    },
-
+#[derive(Subcommand)]
+pub enum ServiceAction {
     #[command(about = "Start mihomo service")]
     Start,
 
@@ -84,12 +175,6 @@ pub enum Commands {
 
     #[command(about = "Show service status")]
     Status,
-
-    #[command(about = "Proxy management")]
-    Proxy {
-        #[command(subcommand)]
-        action: ProxyAction,
-    },
 
     #[command(about = "Stream mihomo logs")]
     Logs {
@@ -106,12 +191,6 @@ pub enum Commands {
 
     #[command(about = "Show memory usage")]
     Memory,
-
-    #[command(about = "Connection management")]
-    Connection {
-        #[command(subcommand)]
-        action: ConnectionAction,
-    },
 }
 
 #[derive(Subcommand)]
@@ -165,8 +244,11 @@ pub enum ConfigKey {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, ConfigAction, ConfigKey};
-    use clap::Parser;
+    use super::{
+        Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, ProxyAction, ServiceAction,
+        VersionAction,
+    };
+    use clap::{CommandFactory, Parser};
 
     #[test]
     fn cli_rejects_invalid_profile_argument() {
@@ -255,17 +337,178 @@ mod tests {
             _ => panic!("expected config unset command"),
         }
     }
+
+    #[test]
+    fn cli_accepts_namespaced_version_and_service_commands() {
+        let version = Cli::try_parse_from(["mihomo-rs", "version", "use", "v1.2.3"])
+            .expect("version use should parse");
+        match version.command {
+            Commands::Version {
+                action: VersionAction::Use { version },
+            } => assert_eq!(version, "v1.2.3"),
+            _ => panic!("expected version use command"),
+        }
+
+        let service = Cli::try_parse_from(["mihomo-rs", "service", "status"])
+            .expect("service status should parse");
+        match service.command {
+            Commands::Service {
+                action: ServiceAction::Status,
+            } => {}
+            _ => panic!("expected service status command"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_connection_flags_and_legacy_forms() {
+        let list = Cli::try_parse_from([
+            "mihomo-rs",
+            "connection",
+            "list",
+            "--host",
+            "example",
+            "--process",
+            "curl",
+        ])
+        .expect("connection list flags should parse");
+        match list.command {
+            Commands::Connection {
+                action: ConnectionAction::List { host, process },
+            } => {
+                assert_eq!(host.as_deref(), Some("example"));
+                assert_eq!(process.as_deref(), Some("curl"));
+            }
+            _ => panic!("expected connection list command"),
+        }
+
+        let close = Cli::try_parse_from([
+            "mihomo-rs",
+            "connection",
+            "close",
+            "--host",
+            "example",
+            "--force",
+        ])
+        .expect("connection close flags should parse");
+        match close.command {
+            Commands::Connection {
+                action:
+                    ConnectionAction::Close {
+                        host, force, id, ..
+                    },
+            } => {
+                assert_eq!(host.as_deref(), Some("example"));
+                assert!(force);
+                assert!(id.is_none());
+            }
+            _ => panic!("expected connection close command"),
+        }
+
+        let legacy = Cli::try_parse_from(["mihomo-rs", "connection", "filter-host", "example"])
+            .expect("legacy filter-host should parse");
+        match legacy.command {
+            Commands::Connection {
+                action: ConnectionAction::FilterHost { host },
+            } => assert_eq!(host, "example"),
+            _ => panic!("expected legacy filter-host command"),
+        }
+    }
+
+    #[test]
+    fn root_help_prefers_namespaced_commands() {
+        let mut command = Cli::command();
+        let mut output = Vec::new();
+        command
+            .write_long_help(&mut output)
+            .expect("render root help");
+        let help = String::from_utf8(output).expect("help should be utf8");
+
+        assert!(help.contains("  version"));
+        assert!(help.contains("  config"));
+        assert!(help.contains("  service"));
+        assert!(help.contains("  proxy"));
+        assert!(help.contains("  connection"));
+        assert!(!help.contains("  install      Install mihomo kernel version"));
+        assert!(!help.contains("  start        Start mihomo service"));
+        assert!(!help.contains("  logs         Stream mihomo logs"));
+    }
+
+    #[test]
+    fn cli_keeps_legacy_root_aliases_available() {
+        let install =
+            Cli::try_parse_from(["mihomo-rs", "install", "stable"]).expect("legacy install");
+        match install.command {
+            Commands::Install { version } => assert_eq!(version.as_deref(), Some("stable")),
+            _ => panic!("expected legacy install command"),
+        }
+
+        let start = Cli::try_parse_from(["mihomo-rs", "start"]).expect("legacy start");
+        match start.command {
+            Commands::Start => {}
+            _ => panic!("expected legacy start command"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_proxy_switch_and_test_all_forms() {
+        let switch = Cli::try_parse_from(["mihomo-rs", "proxy", "switch", "GLOBAL", "HK-01"])
+            .expect("proxy switch should parse");
+        match switch.command {
+            Commands::Proxy {
+                action: ProxyAction::Switch { group, proxy },
+            } => {
+                assert_eq!(group, "GLOBAL");
+                assert_eq!(proxy, "HK-01");
+            }
+            _ => panic!("expected proxy switch command"),
+        }
+
+        let test_all =
+            Cli::try_parse_from(["mihomo-rs", "proxy", "test"]).expect("proxy test should parse");
+        match test_all.command {
+            Commands::Proxy {
+                action:
+                    ProxyAction::Test {
+                        proxy,
+                        timeout,
+                        url,
+                    },
+            } => {
+                assert!(proxy.is_none());
+                assert_eq!(timeout, 5000);
+                assert_eq!(url, "http://www.gstatic.com/generate_204");
+            }
+            _ => panic!("expected proxy test command"),
+        }
+    }
+
+    #[test]
+    fn proxy_help_uses_clearer_terms() {
+        let mut command = Cli::command();
+        let proxy = command
+            .find_subcommand_mut("proxy")
+            .expect("proxy subcommand should exist");
+        let mut output = Vec::new();
+        proxy
+            .write_long_help(&mut output)
+            .expect("render proxy help");
+        let help = String::from_utf8(output).expect("help should be utf8");
+
+        assert!(help.contains("List proxy nodes"));
+        assert!(help.contains("List selectable proxy groups"));
+        assert!(help.contains("Show current proxy selection by group"));
+    }
 }
 
 #[derive(Subcommand)]
 pub enum ProxyAction {
-    #[command(about = "List all proxies")]
+    #[command(about = "List proxy nodes")]
     List,
 
-    #[command(about = "List proxy groups")]
+    #[command(about = "List selectable proxy groups")]
     Groups,
 
-    #[command(about = "Switch proxy in group")]
+    #[command(about = "Select a proxy for a group")]
     Switch {
         #[arg(help = "Group name")]
         group: String,
@@ -273,9 +516,9 @@ pub enum ProxyAction {
         proxy: String,
     },
 
-    #[command(about = "Test proxy delay")]
+    #[command(about = "Test one proxy or all proxies")]
     Test {
-        #[arg(help = "Proxy name (default: test all)")]
+        #[arg(help = "Proxy name; omit to test all proxies")]
         proxy: Option<String>,
         #[arg(short, long, default_value = "http://www.gstatic.com/generate_204")]
         url: String,
@@ -283,14 +526,19 @@ pub enum ProxyAction {
         timeout: u32,
     },
 
-    #[command(about = "Show current proxies")]
+    #[command(about = "Show current proxy selection by group")]
     Current,
 }
 
 #[derive(Subcommand)]
 pub enum ConnectionAction {
     #[command(about = "List active connections")]
-    List,
+    List {
+        #[arg(long, help = "Filter by host name or IP")]
+        host: Option<String>,
+        #[arg(long, help = "Filter by process name")]
+        process: Option<String>,
+    },
 
     #[command(about = "Show connection statistics")]
     Stats,
@@ -298,13 +546,33 @@ pub enum ConnectionAction {
     #[command(about = "Stream connections in real-time")]
     Stream,
 
-    #[command(about = "Close a specific connection")]
+    #[command(about = "Close connections")]
     Close {
-        #[arg(help = "Connection ID")]
-        id: String,
+        #[arg(
+            value_name = "ID",
+            help = "Connection ID (legacy positional form)",
+            conflicts_with_all = ["id", "all", "host", "process"],
+            required = false
+        )]
+        legacy_id: Option<String>,
+        #[arg(long, help = "Connection ID", conflicts_with_all = ["legacy_id", "all", "host", "process"])]
+        id: Option<String>,
+        #[arg(long, help = "Close all connections", conflicts_with_all = ["legacy_id", "id", "host", "process"], default_value_t = false)]
+        all: bool,
+        #[arg(long, help = "Close by host name or IP", conflicts_with_all = ["legacy_id", "id", "all", "process"])]
+        host: Option<String>,
+        #[arg(long, help = "Close by process name", conflicts_with_all = ["legacy_id", "id", "all", "host"])]
+        process: Option<String>,
+        #[arg(
+            short,
+            long,
+            help = "Skip confirmation prompt",
+            default_value = "false"
+        )]
+        force: bool,
     },
 
-    #[command(about = "Close all connections")]
+    #[command(about = "Close all connections", hide = true)]
     CloseAll {
         #[arg(
             short,
@@ -315,19 +583,19 @@ pub enum ConnectionAction {
         force: bool,
     },
 
-    #[command(about = "Filter connections by host")]
+    #[command(about = "Filter connections by host", hide = true)]
     FilterHost {
         #[arg(help = "Host name or IP to filter")]
         host: String,
     },
 
-    #[command(about = "Filter connections by process")]
+    #[command(about = "Filter connections by process", hide = true)]
     FilterProcess {
         #[arg(help = "Process name to filter")]
         process: String,
     },
 
-    #[command(about = "Close connections by host")]
+    #[command(about = "Close connections by host", hide = true)]
     CloseByHost {
         #[arg(help = "Host name or IP")]
         host: String,
@@ -340,7 +608,7 @@ pub enum ConnectionAction {
         force: bool,
     },
 
-    #[command(about = "Close connections by process")]
+    #[command(about = "Close connections by process", hide = true)]
     CloseByProcess {
         #[arg(help = "Process name")]
         process: String,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,5 +1,5 @@
 use crate::core::{validate_profile_name, validate_version_name};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 fn parse_profile_arg(value: &str) -> std::result::Result<String, String> {
     validate_profile_name(value)
@@ -119,6 +119,26 @@ pub enum ConfigAction {
     #[command(about = "List config profiles")]
     List,
 
+    #[command(about = "Show current profile and config path")]
+    Current,
+
+    #[command(about = "Show resolved config directory path")]
+    Path,
+
+    #[command(about = "Set a config option")]
+    Set {
+        #[arg(help = "Config key", value_enum)]
+        key: ConfigKey,
+        #[arg(help = "Config value")]
+        value: String,
+    },
+
+    #[command(about = "Unset a config option")]
+    Unset {
+        #[arg(help = "Config key", value_enum)]
+        key: ConfigKey,
+    },
+
     #[command(about = "Switch to a profile")]
     Use {
         #[arg(help = "Profile name", value_parser = parse_profile_arg)]
@@ -138,9 +158,14 @@ pub enum ConfigAction {
     },
 }
 
+#[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
+pub enum ConfigKey {
+    ConfigsDir,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, ConfigAction};
+    use super::{Cli, Commands, ConfigAction, ConfigKey};
     use clap::Parser;
 
     #[test]
@@ -174,6 +199,60 @@ mod tests {
                 action: ConfigAction::Show { profile },
             } => assert_eq!(profile.as_deref(), Some("alpha-1.2_ok")),
             _ => panic!("expected config show command"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_config_path_command() {
+        let path =
+            Cli::try_parse_from(["mihomo-rs", "config", "path"]).expect("config path should parse");
+        match path.command {
+            Commands::Config {
+                action: ConfigAction::Path,
+            } => {}
+            _ => panic!("expected config path command"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_config_current_command() {
+        let current = Cli::try_parse_from(["mihomo-rs", "config", "current"])
+            .expect("config current should parse");
+        match current.command {
+            Commands::Config {
+                action: ConfigAction::Current,
+            } => {}
+            _ => panic!("expected config current command"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_config_set_and_unset_commands() {
+        let set = Cli::try_parse_from([
+            "mihomo-rs",
+            "config",
+            "set",
+            "configs-dir",
+            "~/Library/Mobile Documents/mihomo-rs/configs",
+        ])
+        .expect("config set should parse");
+        match set.command {
+            Commands::Config {
+                action: ConfigAction::Set { key, value },
+            } => {
+                assert_eq!(key, ConfigKey::ConfigsDir);
+                assert_eq!(value, "~/Library/Mobile Documents/mihomo-rs/configs");
+            }
+            _ => panic!("expected config set command"),
+        }
+
+        let unset = Cli::try_parse_from(["mihomo-rs", "config", "unset", "configs-dir"])
+            .expect("config unset should parse");
+        match unset.command {
+            Commands::Config {
+                action: ConfigAction::Unset { key },
+            } => assert_eq!(key, ConfigKey::ConfigsDir),
+            _ => panic!("expected config unset command"),
         }
     }
 }

--- a/src/cli/handlers/config.rs
+++ b/src/cli/handlers/config.rs
@@ -1,5 +1,5 @@
-use crate::cli::{print_info, print_success, print_table, ConfigAction};
-use crate::config::ConfigManager;
+use crate::cli::{print_info, print_success, print_table, ConfigAction, ConfigKey};
+use crate::config::{ConfigDirSource, ConfigManager};
 
 pub async fn handle_config(action: ConfigAction) -> anyhow::Result<()> {
     let cm = ConfigManager::new()?;
@@ -22,6 +22,39 @@ pub async fn handle_config(action: ConfigAction) -> anyhow::Result<()> {
                 print_table(&["Profile", "Path"], rows);
             }
         }
+        ConfigAction::Current => {
+            let profile = cm.get_current().await?;
+            let path = cm.get_current_path().await?;
+            print_table(
+                &["Profile", "Path"],
+                vec![vec![profile, path.display().to_string()]],
+            );
+        }
+        ConfigAction::Path => {
+            let info = cm.get_config_dir_info()?;
+            println!("{}", info.path.display());
+        }
+        ConfigAction::Set { key, value } => match key {
+            ConfigKey::ConfigsDir => {
+                let resolved = cm.set_configs_dir(&value).await?;
+                print_success(&format!("Set configs-dir to '{}'", resolved.display()));
+                if cm.get_config_dir_info()?.source == ConfigDirSource::Env {
+                    print_info("MIHOMO_CONFIGS_DIR is set and currently overrides config.toml");
+                }
+            }
+        },
+        ConfigAction::Unset { key } => match key {
+            ConfigKey::ConfigsDir => {
+                let resolved = cm.unset_configs_dir().await?;
+                print_success(&format!(
+                    "Unset configs-dir, now using '{}'",
+                    resolved.display()
+                ));
+                if cm.get_config_dir_info()?.source == ConfigDirSource::Env {
+                    print_info("MIHOMO_CONFIGS_DIR is set and currently overrides config.toml");
+                }
+            }
+        },
         ConfigAction::Use { profile } => {
             cm.set_current(&profile).await?;
             print_success(&format!("Switched to profile '{}'", profile));

--- a/src/cli/handlers/connection.rs
+++ b/src/cli/handlers/connection.rs
@@ -3,6 +3,7 @@ use crate::config::ConfigManager;
 use crate::connection::ConnectionManager;
 use crate::core::{Connection, MihomoClient};
 use anyhow::bail;
+use std::cmp::Reverse;
 use std::io::{self, Write};
 
 enum CloseTarget {
@@ -54,7 +55,8 @@ pub async fn handle_connection(action: ConnectionAction) -> anyhow::Result<()> {
 
                 if !snapshot.connections.is_empty() {
                     let mut sorted = snapshot.connections.clone();
-                    sorted.sort_by(|a, b| (b.download + b.upload).cmp(&(a.download + a.upload)));
+                    sorted
+                        .sort_by_key(|connection| Reverse(connection.download + connection.upload));
                     println!("\nTop 3 by traffic:");
                     for (i, conn) in sorted.iter().take(3).enumerate() {
                         let host = if !conn.metadata.host.is_empty() {

--- a/src/cli/handlers/connection.rs
+++ b/src/cli/handlers/connection.rs
@@ -1,8 +1,16 @@
 use crate::cli::{print_info, print_success, print_table, ConnectionAction};
 use crate::config::ConfigManager;
 use crate::connection::ConnectionManager;
-use crate::core::MihomoClient;
+use crate::core::{Connection, MihomoClient};
+use anyhow::bail;
 use std::io::{self, Write};
+
+enum CloseTarget {
+    Id(String),
+    All,
+    Host(String),
+    Process(String),
+}
 
 pub async fn handle_connection(action: ConnectionAction) -> anyhow::Result<()> {
     let cm = ConfigManager::new()?;
@@ -11,39 +19,10 @@ pub async fn handle_connection(action: ConnectionAction) -> anyhow::Result<()> {
     let conn_mgr = ConnectionManager::new(client);
 
     match action {
-        ConnectionAction::List => {
-            let connections = conn_mgr.list().await?;
-            if connections.is_empty() {
-                print_info("No active connections");
-            } else {
-                let rows: Vec<Vec<String>> = connections
-                    .iter()
-                    .map(|c| {
-                        let host = if !c.metadata.host.is_empty() {
-                            c.metadata.host.clone()
-                        } else {
-                            format!(
-                                "{}:{}",
-                                c.metadata.destination_ip, c.metadata.destination_port
-                            )
-                        };
-                        let chain = if !c.chains.is_empty() {
-                            c.chains.join(" -> ")
-                        } else {
-                            "-".to_string()
-                        };
-                        vec![
-                            super::truncate_for_display(&c.id, 8),
-                            host,
-                            chain,
-                            format!("{:.1} KB", c.download as f64 / 1024.0),
-                            format!("{:.1} KB", c.upload as f64 / 1024.0),
-                        ]
-                    })
-                    .collect();
-                print_table(&["ID", "Host", "Chain", "Download", "Upload"], rows);
-                println!("\nTotal connections: {}", connections.len());
-            }
+        ConnectionAction::List { host, process } => {
+            let connections =
+                load_connections(&conn_mgr, host.as_deref(), process.as_deref()).await?;
+            render_connection_list(&connections, host.as_deref(), process.as_deref());
         }
         ConnectionAction::Stats => {
             let (download, upload, count) = conn_mgr.get_statistics().await?;
@@ -94,129 +73,237 @@ pub async fn handle_connection(action: ConnectionAction) -> anyhow::Result<()> {
                 }
             }
         }
-        ConnectionAction::Close { id } => {
+        ConnectionAction::Close {
+            legacy_id,
+            id,
+            all,
+            host,
+            process,
+            force,
+        } => {
+            let target = parse_close_target(legacy_id, id, all, host, process)?;
+            execute_close(&conn_mgr, target, force).await?;
+        }
+        ConnectionAction::CloseAll { force } => {
+            execute_close(&conn_mgr, CloseTarget::All, force).await?;
+        }
+        ConnectionAction::FilterHost { host } => {
+            let connections = load_connections(&conn_mgr, Some(&host), None).await?;
+            render_connection_list(&connections, Some(&host), None);
+        }
+        ConnectionAction::FilterProcess { process } => {
+            let connections = load_connections(&conn_mgr, None, Some(&process)).await?;
+            render_connection_list(&connections, None, Some(&process));
+        }
+        ConnectionAction::CloseByHost { host, force } => {
+            execute_close(&conn_mgr, CloseTarget::Host(host), force).await?;
+        }
+        ConnectionAction::CloseByProcess { process, force } => {
+            execute_close(&conn_mgr, CloseTarget::Process(process), force).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn connection_host_label(connection: &Connection) -> String {
+    if !connection.metadata.host.is_empty() {
+        connection.metadata.host.clone()
+    } else {
+        format!(
+            "{}:{}",
+            connection.metadata.destination_ip, connection.metadata.destination_port
+        )
+    }
+}
+
+fn connection_chain_label(connection: &Connection) -> String {
+    if !connection.chains.is_empty() {
+        connection.chains.join(" -> ")
+    } else {
+        "-".to_string()
+    }
+}
+
+async fn load_connections(
+    conn_mgr: &ConnectionManager,
+    host: Option<&str>,
+    process: Option<&str>,
+) -> crate::core::Result<Vec<Connection>> {
+    let mut connections = conn_mgr.list().await?;
+    if let Some(host_filter) = host {
+        connections.retain(|c| c.metadata.host.contains(host_filter));
+    }
+    if let Some(process_filter) = process {
+        connections.retain(|c| c.metadata.process_path.contains(process_filter));
+    }
+    Ok(connections)
+}
+
+fn render_connection_list(connections: &[Connection], host: Option<&str>, process: Option<&str>) {
+    if connections.is_empty() {
+        match (host, process) {
+            (Some(host), Some(process)) => print_info(&format!(
+                "No connections found for host '{}' and process '{}'",
+                host, process
+            )),
+            (Some(host), None) => print_info(&format!("No connections found for host '{}'", host)),
+            (None, Some(process)) => {
+                print_info(&format!("No connections found for process '{}'", process))
+            }
+            (None, None) => print_info("No active connections"),
+        }
+        return;
+    }
+
+    if process.is_some() {
+        let rows: Vec<Vec<String>> = connections
+            .iter()
+            .map(|c| {
+                vec![
+                    super::truncate_for_display(&c.id, 8),
+                    connection_host_label(c),
+                    c.metadata.process_path.clone(),
+                    format!("{:.1} KB", c.download as f64 / 1024.0),
+                    format!("{:.1} KB", c.upload as f64 / 1024.0),
+                ]
+            })
+            .collect();
+        print_table(&["ID", "Host", "Process", "Download", "Upload"], rows);
+    } else {
+        let rows: Vec<Vec<String>> = connections
+            .iter()
+            .map(|c| {
+                vec![
+                    super::truncate_for_display(&c.id, 8),
+                    connection_host_label(c),
+                    connection_chain_label(c),
+                    format!("{:.1} KB", c.download as f64 / 1024.0),
+                    format!("{:.1} KB", c.upload as f64 / 1024.0),
+                ]
+            })
+            .collect();
+        print_table(&["ID", "Host", "Chain", "Download", "Upload"], rows);
+    }
+
+    match (host, process) {
+        (Some(host), Some(process)) => println!(
+            "\nFound {} connection(s) for host '{}' and process '{}'",
+            connections.len(),
+            host,
+            process
+        ),
+        (Some(host), None) => {
+            println!("\nFound {} connection(s) for '{}'", connections.len(), host)
+        }
+        (None, Some(process)) => println!(
+            "\nFound {} connection(s) for process '{}'",
+            connections.len(),
+            process
+        ),
+        (None, None) => println!("\nTotal connections: {}", connections.len()),
+    }
+}
+
+fn parse_close_target(
+    legacy_id: Option<String>,
+    id: Option<String>,
+    all: bool,
+    host: Option<String>,
+    process: Option<String>,
+) -> anyhow::Result<CloseTarget> {
+    let selected = legacy_id.is_some() as u8
+        + id.is_some() as u8
+        + all as u8
+        + host.is_some() as u8
+        + process.is_some() as u8;
+    if selected != 1 {
+        bail!("Specify exactly one of ID, --id, --all, --host, or --process");
+    }
+
+    if let Some(id) = legacy_id.or(id) {
+        return Ok(CloseTarget::Id(id));
+    }
+    if all {
+        return Ok(CloseTarget::All);
+    }
+    if let Some(host) = host {
+        return Ok(CloseTarget::Host(host));
+    }
+    if let Some(process) = process {
+        return Ok(CloseTarget::Process(process));
+    }
+
+    bail!("Specify exactly one of ID, --id, --all, --host, or --process");
+}
+
+fn confirm(prompt: &str) -> anyhow::Result<bool> {
+    print!("{}", prompt);
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(input.trim().eq_ignore_ascii_case("y"))
+}
+
+async fn execute_close(
+    conn_mgr: &ConnectionManager,
+    target: CloseTarget,
+    force: bool,
+) -> anyhow::Result<()> {
+    match target {
+        CloseTarget::Id(id) => {
             conn_mgr.close(&id).await?;
             print_success(&format!(
                 "Closed connection {}",
                 super::truncate_for_display(&id, 8)
             ));
         }
-        ConnectionAction::CloseAll { force } => {
-            if !force {
-                print!("Are you sure you want to close all connections? [y/N]: ");
-                io::stdout().flush()?;
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                if !input.trim().eq_ignore_ascii_case("y") {
-                    print_info("Cancelled");
-                    return Ok(());
-                }
+        CloseTarget::All => {
+            if !force && !confirm("Are you sure you want to close all connections? [y/N]: ")? {
+                print_info("Cancelled");
+                return Ok(());
             }
-
             conn_mgr.close_all().await?;
             print_success("Closed all connections");
         }
-        ConnectionAction::FilterHost { host } => {
-            let connections = conn_mgr.filter_by_host(&host).await?;
-            if connections.is_empty() {
-                print_info(&format!("No connections found for host '{}'", host));
-            } else {
-                let rows: Vec<Vec<String>> = connections
-                    .iter()
-                    .map(|c| {
-                        vec![
-                            super::truncate_for_display(&c.id, 8),
-                            c.metadata.host.clone(),
-                            c.chains.join(" -> "),
-                            format!("{:.1} KB", c.download as f64 / 1024.0),
-                            format!("{:.1} KB", c.upload as f64 / 1024.0),
-                        ]
-                    })
-                    .collect();
-                print_table(&["ID", "Host", "Chain", "Download", "Upload"], rows);
-                println!("\nFound {} connection(s) for '{}'", connections.len(), host);
-            }
-        }
-        ConnectionAction::FilterProcess { process } => {
-            let connections = conn_mgr.filter_by_process(&process).await?;
-            if connections.is_empty() {
-                print_info(&format!("No connections found for process '{}'", process));
-            } else {
-                let rows: Vec<Vec<String>> = connections
-                    .iter()
-                    .map(|c| {
-                        let host = if !c.metadata.host.is_empty() {
-                            c.metadata.host.clone()
-                        } else {
-                            c.metadata.destination_ip.clone()
-                        };
-                        vec![
-                            super::truncate_for_display(&c.id, 8),
-                            host,
-                            c.metadata.process_path.clone(),
-                            format!("{:.1} KB", c.download as f64 / 1024.0),
-                            format!("{:.1} KB", c.upload as f64 / 1024.0),
-                        ]
-                    })
-                    .collect();
-                print_table(&["ID", "Host", "Process", "Download", "Upload"], rows);
-                println!(
-                    "\nFound {} connection(s) for process '{}'",
-                    connections.len(),
-                    process
-                );
-            }
-        }
-        ConnectionAction::CloseByHost { host, force } => {
-            let connections = conn_mgr.filter_by_host(&host).await?;
+        CloseTarget::Host(host) => {
+            let connections = load_connections(conn_mgr, Some(&host), None).await?;
             if connections.is_empty() {
                 print_info(&format!("No connections found for host '{}'", host));
                 return Ok(());
             }
-
-            if !force {
-                print!(
+            if !force
+                && !confirm(&format!(
                     "About to close {} connection(s) for host '{}'. Continue? [y/N]: ",
                     connections.len(),
                     host
-                );
-                io::stdout().flush()?;
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                if !input.trim().eq_ignore_ascii_case("y") {
-                    print_info("Cancelled");
-                    return Ok(());
-                }
+                ))?
+            {
+                print_info("Cancelled");
+                return Ok(());
             }
-
             let count = conn_mgr.close_by_host(&host).await?;
             print_success(&format!(
                 "Closed {} connection(s) for host '{}'",
                 count, host
             ));
         }
-        ConnectionAction::CloseByProcess { process, force } => {
-            let connections = conn_mgr.filter_by_process(&process).await?;
+        CloseTarget::Process(process) => {
+            let connections = load_connections(conn_mgr, None, Some(&process)).await?;
             if connections.is_empty() {
                 print_info(&format!("No connections found for process '{}'", process));
                 return Ok(());
             }
-
-            if !force {
-                print!(
+            if !force
+                && !confirm(&format!(
                     "About to close {} connection(s) for process '{}'. Continue? [y/N]: ",
                     connections.len(),
                     process
-                );
-                io::stdout().flush()?;
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                if !input.trim().eq_ignore_ascii_case("y") {
-                    print_info("Cancelled");
-                    return Ok(());
-                }
+                ))?
+            {
+                print_info("Cancelled");
+                return Ok(());
             }
-
             let count = conn_mgr.close_by_process(&process).await?;
             print_success(&format!(
                 "Closed {} connection(s) for process '{}'",
@@ -224,6 +311,56 @@ pub async fn handle_connection(action: ConnectionAction) -> anyhow::Result<()> {
             ));
         }
     }
-
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_close_target, CloseTarget};
+
+    #[test]
+    fn parse_close_target_accepts_new_and_legacy_forms() {
+        match parse_close_target(Some("legacy-id".to_string()), None, false, None, None)
+            .expect("legacy id should parse")
+        {
+            CloseTarget::Id(id) => assert_eq!(id, "legacy-id"),
+            _ => panic!("expected id target"),
+        }
+
+        match parse_close_target(None, Some("flag-id".to_string()), false, None, None)
+            .expect("flag id should parse")
+        {
+            CloseTarget::Id(id) => assert_eq!(id, "flag-id"),
+            _ => panic!("expected id target"),
+        }
+
+        assert!(matches!(
+            parse_close_target(None, None, true, None, None).expect("all should parse"),
+            CloseTarget::All
+        ));
+        assert!(matches!(
+            parse_close_target(None, None, false, Some("example".to_string()), None)
+                .expect("host should parse"),
+            CloseTarget::Host(_)
+        ));
+        assert!(matches!(
+            parse_close_target(None, None, false, None, Some("curl".to_string()))
+                .expect("process should parse"),
+            CloseTarget::Process(_)
+        ));
+    }
+
+    #[test]
+    fn parse_close_target_rejects_missing_or_ambiguous_selection() {
+        assert!(parse_close_target(None, None, false, None, None).is_err());
+        assert!(parse_close_target(None, Some("id".to_string()), true, None, None).is_err());
+        assert!(parse_close_target(
+            Some("legacy".to_string()),
+            None,
+            false,
+            Some("example".to_string()),
+            None,
+        )
+        .is_err());
+    }
 }

--- a/src/cli/handlers/mod.rs
+++ b/src/cli/handlers/mod.rs
@@ -9,6 +9,7 @@ use crate::cli::Commands;
 
 pub async fn run_cli_command(command: Commands) -> anyhow::Result<()> {
     match command {
+        Commands::Version { action } => version::handle_version(action).await,
         Commands::Install { version } => version::handle_install(version).await,
         Commands::Update => version::handle_update().await,
         Commands::Default { version } => version::handle_default(version).await,
@@ -16,6 +17,7 @@ pub async fn run_cli_command(command: Commands) -> anyhow::Result<()> {
         Commands::ListRemote { limit } => version::handle_list_remote(limit).await,
         Commands::Uninstall { version } => version::handle_uninstall(version).await,
         Commands::Config { action } => config::handle_config(action).await,
+        Commands::Service { action } => service::handle_service(action).await,
         Commands::Start => service::handle_start().await,
         Commands::Stop => service::handle_stop().await,
         Commands::Restart => service::handle_restart().await,

--- a/src/cli/handlers/service.rs
+++ b/src/cli/handlers/service.rs
@@ -1,7 +1,20 @@
-use crate::cli::{print_info, print_success};
+use crate::cli::handlers::telemetry;
+use crate::cli::{print_info, print_success, ServiceAction};
 use crate::config::ConfigManager;
 use crate::service::{ServiceManager, ServiceStatus};
 use crate::version::VersionManager;
+
+pub async fn handle_service(action: ServiceAction) -> anyhow::Result<()> {
+    match action {
+        ServiceAction::Start => handle_start().await,
+        ServiceAction::Stop => handle_stop().await,
+        ServiceAction::Restart => handle_restart().await,
+        ServiceAction::Status => handle_status().await,
+        ServiceAction::Logs { level } => telemetry::handle_logs(level).await,
+        ServiceAction::Traffic => telemetry::handle_traffic().await,
+        ServiceAction::Memory => telemetry::handle_memory().await,
+    }
+}
 
 pub async fn handle_start() -> anyhow::Result<()> {
     let vm = VersionManager::new()?;

--- a/src/cli/handlers/version.rs
+++ b/src/cli/handlers/version.rs
@@ -1,5 +1,16 @@
-use crate::cli::{print_info, print_success, print_table};
+use crate::cli::{print_info, print_success, print_table, VersionAction};
 use crate::version::{Channel, VersionManager};
+
+pub async fn handle_version(action: VersionAction) -> anyhow::Result<()> {
+    match action {
+        VersionAction::Install { version } => handle_install(version).await,
+        VersionAction::Update => handle_update().await,
+        VersionAction::Use { version } => handle_default(version).await,
+        VersionAction::List => handle_list().await,
+        VersionAction::ListRemote { limit } => handle_list_remote(limit).await,
+        VersionAction::Uninstall { version } => handle_uninstall(version).await,
+    }
+}
 
 pub async fn handle_install(version: Option<String>) -> anyhow::Result<()> {
     let vm = VersionManager::new()?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,10 @@ pub mod error_hint;
 pub mod handlers;
 pub mod output;
 
-pub use commands::{Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, ProxyAction};
+pub use commands::{
+    Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, ProxyAction, ServiceAction,
+    VersionAction,
+};
 pub use error_hint::format_cli_error;
 pub use handlers::run_cli_command;
 pub use output::{print_error, print_info, print_success, print_table};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,7 @@ pub mod error_hint;
 pub mod handlers;
 pub mod output;
 
-pub use commands::{Cli, Commands, ConfigAction, ConnectionAction, ProxyAction};
+pub use commands::{Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, ProxyAction};
 pub use error_hint::format_cli_error;
 pub use handlers::run_cli_command;
 pub use output::{print_error, print_info, print_success, print_table};

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -593,6 +593,10 @@ mod tests {
 
     #[tokio::test]
     async fn list_profiles_ignores_non_yaml_entries() {
+        let _guard = env_lock().lock().await;
+        let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+        std::env::remove_var("MIHOMO_CONFIGS_DIR");
+
         let temp = tempdir().expect("create temp dir");
         let manager =
             ConfigManager::with_home(temp.path().to_path_buf()).expect("create config manager");
@@ -610,10 +614,18 @@ mod tests {
 
         let profiles = manager.list_profiles().await.expect("list profiles");
         assert!(profiles.is_empty());
+
+        if let Some(value) = old_value {
+            std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+        }
     }
 
     #[tokio::test]
     async fn get_current_path_uses_selected_profile() {
+        let _guard = env_lock().lock().await;
+        let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+        std::env::remove_var("MIHOMO_CONFIGS_DIR");
+
         let temp = tempdir().expect("create temp dir");
         let manager =
             ConfigManager::with_home(temp.path().to_path_buf()).expect("create config manager");
@@ -638,10 +650,18 @@ mod tests {
                 .expect("resolve config dir")
                 .join("alpha.yaml")
         );
+
+        if let Some(value) = old_value {
+            std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+        }
     }
 
     #[tokio::test]
     async fn unit_module_profile_lifecycle_hits_file_branches() {
+        let _guard = env_lock().lock().await;
+        let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+        std::env::remove_var("MIHOMO_CONFIGS_DIR");
+
         let temp = tempdir().expect("create temp dir");
         let manager =
             ConfigManager::with_home(temp.path().to_path_buf()).expect("create config manager");
@@ -686,11 +706,21 @@ mod tests {
                 .expect("resolve config dir")
                 .join("alpha.yaml")
         );
-        assert!(manager
-            .ensure_external_controller()
+
+        manager
+            .save(
+                "alpha",
+                "port: 7890\nsocks-port: 7891\nexternal-controller: https://example.com:18443\n",
+            )
             .await
-            .expect("ensure external controller")
-            .starts_with("http://127.0.0.1:"));
+            .expect("rewrite alpha with remote external controller");
+        assert_eq!(
+            manager
+                .ensure_external_controller()
+                .await
+                .expect("ensure external controller"),
+            "https://example.com:18443"
+        );
 
         manager
             .delete_profile("beta")
@@ -701,10 +731,18 @@ mod tests {
             .expect("resolve config dir")
             .join("beta.yaml")
             .exists());
+
+        if let Some(value) = old_value {
+            std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+        }
     }
 
     #[tokio::test]
     async fn resolve_config_dir_supports_paths_config_in_settings() {
+        let _guard = env_lock().lock().await;
+        let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+        std::env::remove_var("MIHOMO_CONFIGS_DIR");
+
         let temp = tempdir().expect("create temp dir");
         let home = temp.path().to_path_buf();
         let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -721,6 +759,10 @@ mod tests {
             .expect("resolve config dir info");
         assert_eq!(resolved.path, home.join("cloud/configs"));
         assert_eq!(resolved.source, ConfigDirSource::Settings);
+
+        if let Some(value) = old_value {
+            std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+        }
     }
 
     #[tokio::test]
@@ -756,6 +798,10 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_config_dir_defaults_when_not_configured() {
+        let _guard = env_lock().lock().await;
+        let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+        std::env::remove_var("MIHOMO_CONFIGS_DIR");
+
         let temp = tempdir().expect("create temp dir");
         let home = temp.path().to_path_buf();
         let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -765,5 +811,9 @@ mod tests {
             .expect("resolve config dir info");
         assert_eq!(resolved.path, home.join("configs"));
         assert_eq!(resolved.source, ConfigDirSource::Default);
+
+        if let Some(value) = old_value {
+            std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+        }
     }
 }

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -209,7 +209,7 @@ impl ConfigManager {
         }
 
         self.write_settings_value(&config).await?;
-        Ok(self.resolve_config_dir()?)
+        self.resolve_config_dir()
     }
 
     pub async fn unset_configs_dir(&self) -> Result<PathBuf> {
@@ -217,11 +217,9 @@ impl ConfigManager {
 
         if let toml::Value::Table(ref mut table) = config {
             let mut remove_paths_table = false;
-            if let Some(paths_table) = table.get_mut("paths") {
-                if let toml::Value::Table(paths) = paths_table {
-                    paths.remove("configs_dir");
-                    remove_paths_table = paths.is_empty();
-                }
+            if let Some(toml::Value::Table(paths)) = table.get_mut("paths") {
+                paths.remove("configs_dir");
+                remove_paths_table = paths.is_empty();
             }
 
             if remove_paths_table {
@@ -230,7 +228,7 @@ impl ConfigManager {
         }
 
         self.write_settings_value(&config).await?;
-        Ok(self.resolve_config_dir()?)
+        self.resolve_config_dir()
     }
 
     pub async fn load(&self, profile: &str) -> Result<String> {

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -3,13 +3,48 @@ use crate::core::{
     find_available_port, get_home_dir, is_port_available, validate_profile_name, ErrorCode,
     MihomoError, Result,
 };
-use std::path::PathBuf;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 use url::Url;
 
 pub struct ConfigManager {
     config_dir: PathBuf,
     settings_file: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigDirSource {
+    Env,
+    Settings,
+    Default,
+}
+
+impl ConfigDirSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Settings => "config.toml",
+            Self::Default => "default",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigDirInfo {
+    pub path: PathBuf,
+    pub source: ConfigDirSource,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ConfigSettings {
+    #[serde(default)]
+    paths: PathSettings,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PathSettings {
+    configs_dir: Option<String>,
 }
 
 impl ConfigManager {
@@ -35,9 +70,173 @@ impl ConfigManager {
         })
     }
 
+    fn home_dir(&self) -> PathBuf {
+        self.settings_file
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf()
+    }
+
+    fn expand_tilde(path: &str) -> Result<PathBuf> {
+        if path == "~" {
+            return dirs::home_dir()
+                .ok_or_else(|| MihomoError::config("Could not determine home directory"));
+        }
+
+        if let Some(suffix) = path.strip_prefix("~/") {
+            return dirs::home_dir()
+                .ok_or_else(|| MihomoError::config("Could not determine home directory"))
+                .map(|home| home.join(suffix));
+        }
+
+        Ok(PathBuf::from(path))
+    }
+
+    fn normalize_configs_dir(&self, raw_path: &str) -> Result<PathBuf> {
+        let trimmed = raw_path.trim();
+        if trimmed.is_empty() {
+            return Err(MihomoError::config(
+                "Invalid configs directory: path is empty",
+            ));
+        }
+
+        let path = Self::expand_tilde(trimmed)?;
+        if path.is_absolute() {
+            Ok(path)
+        } else {
+            Ok(self.home_dir().join(path))
+        }
+    }
+
+    fn resolve_config_dir_info(&self) -> Result<ConfigDirInfo> {
+        if let Ok(dir) = std::env::var("MIHOMO_CONFIGS_DIR") {
+            return Ok(ConfigDirInfo {
+                path: self.normalize_configs_dir(&dir)?,
+                source: ConfigDirSource::Env,
+            });
+        }
+
+        if !self.settings_file.exists() {
+            return Ok(ConfigDirInfo {
+                path: self.config_dir.clone(),
+                source: ConfigDirSource::Default,
+            });
+        }
+
+        let content = match std::fs::read_to_string(&self.settings_file) {
+            Ok(content) => content,
+            Err(err) => {
+                return Err(MihomoError::config(format!(
+                    "Failed to read config: {}",
+                    err
+                )));
+            }
+        };
+
+        let settings: ConfigSettings = match toml::from_str(&content) {
+            Ok(settings) => settings,
+            Err(err) => {
+                log::warn!(
+                    "Failed to parse settings file '{}': {}, falling back to default configs dir",
+                    self.settings_file.display(),
+                    err
+                );
+                return Ok(ConfigDirInfo {
+                    path: self.config_dir.clone(),
+                    source: ConfigDirSource::Default,
+                });
+            }
+        };
+
+        if let Some(path) = settings.paths.configs_dir.as_deref() {
+            return Ok(ConfigDirInfo {
+                path: self.normalize_configs_dir(path)?,
+                source: ConfigDirSource::Settings,
+            });
+        }
+
+        Ok(ConfigDirInfo {
+            path: self.config_dir.clone(),
+            source: ConfigDirSource::Default,
+        })
+    }
+
+    fn resolve_config_dir(&self) -> Result<PathBuf> {
+        Ok(self.resolve_config_dir_info()?.path)
+    }
+
+    async fn read_settings_value(&self) -> Result<toml::Value> {
+        if self.settings_file.exists() {
+            let content = fs::read_to_string(&self.settings_file).await?;
+            toml::from_str(&content)
+                .map_err(|e| MihomoError::config(format!("Invalid config: {}", e)))
+        } else {
+            Ok(toml::Value::Table(toml::map::Map::new()))
+        }
+    }
+
+    async fn write_settings_value(&self, config: &toml::Value) -> Result<()> {
+        if let Some(parent) = self.settings_file.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+
+        let content = toml::to_string(config)
+            .map_err(|e| MihomoError::config(format!("Failed to serialize config: {}", e)))?;
+        fs::write(&self.settings_file, content).await?;
+        Ok(())
+    }
+
+    pub fn get_config_dir_info(&self) -> Result<ConfigDirInfo> {
+        self.resolve_config_dir_info()
+    }
+
+    pub async fn set_configs_dir(&self, path: &str) -> Result<PathBuf> {
+        let trimmed = path.trim();
+        let _ = self.normalize_configs_dir(trimmed)?;
+
+        let mut config = self.read_settings_value().await?;
+        if let toml::Value::Table(ref mut table) = config {
+            let paths_table = table
+                .entry("paths".to_string())
+                .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+
+            if let toml::Value::Table(ref mut paths) = paths_table {
+                paths.insert(
+                    "configs_dir".to_string(),
+                    toml::Value::String(trimmed.to_string()),
+                );
+            }
+        }
+
+        self.write_settings_value(&config).await?;
+        Ok(self.resolve_config_dir()?)
+    }
+
+    pub async fn unset_configs_dir(&self) -> Result<PathBuf> {
+        let mut config = self.read_settings_value().await?;
+
+        if let toml::Value::Table(ref mut table) = config {
+            let mut remove_paths_table = false;
+            if let Some(paths_table) = table.get_mut("paths") {
+                if let toml::Value::Table(paths) = paths_table {
+                    paths.remove("configs_dir");
+                    remove_paths_table = paths.is_empty();
+                }
+            }
+
+            if remove_paths_table {
+                table.remove("paths");
+            }
+        }
+
+        self.write_settings_value(&config).await?;
+        Ok(self.resolve_config_dir()?)
+    }
+
     pub async fn load(&self, profile: &str) -> Result<String> {
         validate_profile_name(profile)?;
-        let path = self.config_dir.join(format!("{}.yaml", profile));
+        let config_dir = self.resolve_config_dir()?;
+        let path = config_dir.join(format!("{}.yaml", profile));
         if !path.exists() {
             return Err(MihomoError::NotFound(format!(
                 "Profile '{}' not found",
@@ -51,25 +250,27 @@ impl ConfigManager {
 
     pub async fn save(&self, profile: &str, content: &str) -> Result<()> {
         validate_profile_name(profile)?;
-        fs::create_dir_all(&self.config_dir).await?;
+        let config_dir = self.resolve_config_dir()?;
+        fs::create_dir_all(&config_dir).await?;
 
         serde_yaml::from_str::<serde_yaml::Value>(content)?;
 
-        let path = self.config_dir.join(format!("{}.yaml", profile));
+        let path = config_dir.join(format!("{}.yaml", profile));
         fs::write(&path, content).await?;
 
         Ok(())
     }
 
     pub async fn list_profiles(&self) -> Result<Vec<Profile>> {
-        if !self.config_dir.exists() {
+        let config_dir = self.resolve_config_dir()?;
+        if !config_dir.exists() {
             return Ok(vec![]);
         }
 
         let current = self.get_current().await.ok();
         let mut profiles = vec![];
 
-        let mut entries = fs::read_dir(&self.config_dir).await?;
+        let mut entries = fs::read_dir(&config_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
             if path.extension().and_then(|s| s.to_str()) == Some("yaml") {
@@ -89,7 +290,8 @@ impl ConfigManager {
 
     pub async fn delete_profile(&self, profile: &str) -> Result<()> {
         validate_profile_name(profile)?;
-        let path = self.config_dir.join(format!("{}.yaml", profile));
+        let config_dir = self.resolve_config_dir()?;
+        let path = config_dir.join(format!("{}.yaml", profile));
         if !path.exists() {
             return Err(MihomoError::NotFound(format!(
                 "Profile '{}' not found",
@@ -108,7 +310,8 @@ impl ConfigManager {
 
     pub async fn set_current(&self, profile: &str) -> Result<()> {
         validate_profile_name(profile)?;
-        let path = self.config_dir.join(format!("{}.yaml", profile));
+        let config_dir = self.resolve_config_dir()?;
+        let path = config_dir.join(format!("{}.yaml", profile));
         if !path.exists() {
             return Err(MihomoError::NotFound(format!(
                 "Profile '{}' not found",
@@ -116,17 +319,7 @@ impl ConfigManager {
             )));
         }
 
-        if let Some(parent) = self.settings_file.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-
-        let mut config = if self.settings_file.exists() {
-            let content = fs::read_to_string(&self.settings_file).await?;
-            toml::from_str(&content)
-                .map_err(|e| MihomoError::config(format!("Invalid config: {}", e)))?
-        } else {
-            toml::Value::Table(toml::map::Map::new())
-        };
+        let mut config = self.read_settings_value().await?;
 
         if let toml::Value::Table(ref mut table) = config {
             let default_table = table
@@ -141,9 +334,7 @@ impl ConfigManager {
             }
         }
 
-        let content = toml::to_string(&config)
-            .map_err(|e| MihomoError::config(format!("Failed to serialize config: {}", e)))?;
-        fs::write(&self.settings_file, content).await?;
+        self.write_settings_value(&config).await?;
 
         Ok(())
     }
@@ -168,14 +359,14 @@ impl ConfigManager {
     pub async fn get_current_path(&self) -> Result<PathBuf> {
         let profile = self.get_current().await?;
         validate_profile_name(&profile)?;
-        Ok(self.config_dir.join(format!("{}.yaml", profile)))
+        Ok(self.resolve_config_dir()?.join(format!("{}.yaml", profile)))
     }
 
     /// Ensure a default config file exists, create one if it doesn't
     pub async fn ensure_default_config(&self) -> Result<()> {
         let profile = self.get_current().await?;
         validate_profile_name(&profile)?;
-        let path = self.config_dir.join(format!("{}.yaml", profile));
+        let path = self.resolve_config_dir()?.join(format!("{}.yaml", profile));
 
         if !path.exists() {
             log::info!("Default config '{}' not found, creating...", profile);
@@ -345,9 +536,17 @@ external-controller: 127.0.0.1:{}
 
 #[cfg(test)]
 mod tests {
+    use super::ConfigDirSource;
     use super::ConfigManager;
+    use std::sync::OnceLock;
     use tempfile::tempdir;
     use tokio::fs;
+    use tokio::sync::Mutex;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn sample_config() -> &'static str {
         "port: 7890\nsocks-port: 7891\nexternal-controller: 127.0.0.1:9090\n"
@@ -399,12 +598,13 @@ mod tests {
         let temp = tempdir().expect("create temp dir");
         let manager =
             ConfigManager::with_home(temp.path().to_path_buf()).expect("create config manager");
+        let config_dir = manager.resolve_config_dir().expect("resolve config dir");
 
-        fs::create_dir_all(&manager.config_dir)
+        fs::create_dir_all(&config_dir)
             .await
             .expect("create config dir");
         fs::write(
-            manager.config_dir.join("notes.txt"),
+            config_dir.join("notes.txt"),
             "this should not be treated as profile",
         )
         .await
@@ -433,7 +633,13 @@ mod tests {
             .expect("set current profile");
 
         let current_path = manager.get_current_path().await.expect("get current path");
-        assert_eq!(current_path, manager.config_dir.join("alpha.yaml"));
+        assert_eq!(
+            current_path,
+            manager
+                .resolve_config_dir()
+                .expect("resolve config dir")
+                .join("alpha.yaml")
+        );
     }
 
     #[tokio::test]
@@ -477,7 +683,10 @@ mod tests {
         );
         assert_eq!(
             manager.get_current_path().await.expect("current path"),
-            manager.config_dir.join("alpha.yaml")
+            manager
+                .resolve_config_dir()
+                .expect("resolve config dir")
+                .join("alpha.yaml")
         );
         assert!(manager
             .ensure_external_controller()
@@ -489,6 +698,74 @@ mod tests {
             .delete_profile("beta")
             .await
             .expect("delete non-active profile should succeed");
-        assert!(!manager.config_dir.join("beta.yaml").exists());
+        assert!(!manager
+            .resolve_config_dir()
+            .expect("resolve config dir")
+            .join("beta.yaml")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn resolve_config_dir_supports_paths_config_in_settings() {
+        let temp = tempdir().expect("create temp dir");
+        let home = temp.path().to_path_buf();
+        let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+        fs::write(
+            home.join("config.toml"),
+            "[paths]\nconfigs_dir = \"cloud/configs\"\n",
+        )
+        .await
+        .expect("write settings");
+
+        let resolved = manager
+            .get_config_dir_info()
+            .expect("resolve config dir info");
+        assert_eq!(resolved.path, home.join("cloud/configs"));
+        assert_eq!(resolved.source, ConfigDirSource::Settings);
+    }
+
+    #[tokio::test]
+    async fn resolve_config_dir_prefers_env_override() {
+        let _guard = env_lock().lock().await;
+        let temp = tempdir().expect("create temp dir");
+        let home = temp.path().to_path_buf();
+        let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+        fs::write(
+            home.join("config.toml"),
+            "[paths]\nconfigs_dir = \"cloud/configs\"\n",
+        )
+        .await
+        .expect("write settings");
+
+        let env_dir = home.join("override-configs");
+        let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+        std::env::set_var("MIHOMO_CONFIGS_DIR", &env_dir);
+
+        let resolved = manager
+            .get_config_dir_info()
+            .expect("resolve config dir info");
+        assert_eq!(resolved.path, env_dir);
+        assert_eq!(resolved.source, ConfigDirSource::Env);
+
+        if let Some(value) = old_value {
+            std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+        } else {
+            std::env::remove_var("MIHOMO_CONFIGS_DIR");
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_config_dir_defaults_when_not_configured() {
+        let temp = tempdir().expect("create temp dir");
+        let home = temp.path().to_path_buf();
+        let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+        let resolved = manager
+            .get_config_dir_info()
+            .expect("resolve config dir info");
+        assert_eq!(resolved.path, home.join("configs"));
+        assert_eq!(resolved.source, ConfigDirSource::Default);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 pub mod manager;
 pub mod profile;
 
-pub use manager::ConfigManager;
+pub use manager::{ConfigDirInfo, ConfigDirSource, ConfigManager};
 pub use profile::Profile;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod proxy;
 pub mod service;
 pub mod version;
 
-pub use config::{ConfigManager, Profile};
+pub use config::{ConfigDirInfo, ConfigDirSource, ConfigManager, Profile};
 pub use connection::ConnectionManager;
 pub use core::{MihomoClient, MihomoError, Result};
 pub use proxy::ProxyManager;

--- a/tests/cli_handlers_spec.rs
+++ b/tests/cli_handlers_spec.rs
@@ -2,7 +2,10 @@
 
 mod common;
 
-use mihomo_rs::cli::{run_cli_command, Commands, ConfigAction, ConnectionAction, ProxyAction};
+use mihomo_rs::cli::{
+    run_cli_command, Commands, ConfigAction, ConnectionAction, ProxyAction, ServiceAction,
+    VersionAction,
+};
 use mihomo_rs::{ConfigManager, VersionManager};
 use mockito::{Matcher, Server};
 use std::env;
@@ -384,7 +387,10 @@ async fn run_cli_command_covers_proxy_connection_and_memory_paths() {
     .expect("proxy test all");
 
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::List,
+        action: ConnectionAction::List {
+            host: None,
+            process: None,
+        },
     })
     .await
     .expect("connection list");
@@ -394,42 +400,64 @@ async fn run_cli_command_covers_proxy_connection_and_memory_paths() {
     .await
     .expect("connection stats");
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::FilterHost {
-            host: "example".to_string(),
+        action: ConnectionAction::List {
+            host: Some("example".to_string()),
+            process: None,
         },
     })
     .await
     .expect("connection filter host");
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::FilterProcess {
-            process: "curl".to_string(),
+        action: ConnectionAction::List {
+            host: None,
+            process: Some("curl".to_string()),
         },
     })
     .await
     .expect("connection filter process");
     run_cli_command(Commands::Connection {
         action: ConnectionAction::Close {
-            id: "c1".to_string(),
+            legacy_id: None,
+            id: Some("c1".to_string()),
+            all: false,
+            host: None,
+            process: None,
+            force: false,
         },
     })
     .await
     .expect("connection close");
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::CloseAll { force: true },
+        action: ConnectionAction::Close {
+            legacy_id: None,
+            id: None,
+            all: true,
+            host: None,
+            process: None,
+            force: true,
+        },
     })
     .await
     .expect("connection close all");
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::CloseByHost {
-            host: "example".to_string(),
+        action: ConnectionAction::Close {
+            legacy_id: None,
+            id: None,
+            all: false,
+            host: Some("example".to_string()),
+            process: None,
             force: true,
         },
     })
     .await
     .expect("connection close by host");
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::CloseByProcess {
-            process: "curl".to_string(),
+        action: ConnectionAction::Close {
+            legacy_id: None,
+            id: None,
+            all: false,
+            host: None,
+            process: Some("curl".to_string()),
             force: true,
         },
     })
@@ -621,7 +649,10 @@ async fn run_cli_command_covers_connection_stream_and_empty_branches() {
         .await;
 
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::List,
+        action: ConnectionAction::List {
+            host: None,
+            process: None,
+        },
     })
     .await
     .expect("connection list empty");
@@ -657,7 +688,10 @@ async fn run_cli_command_covers_connection_stream_and_empty_branches() {
     .expect("connection close by process empty");
 
     run_cli_command(Commands::Connection {
-        action: ConnectionAction::List,
+        action: ConnectionAction::List {
+            host: None,
+            process: None,
+        },
     })
     .await
     .expect("connection list edge payload");
@@ -745,21 +779,36 @@ async fn run_cli_command_covers_connection_confirmation_branches() {
 
     with_mocked_stdin("n\nn\nn\n", async {
         run_cli_command(Commands::Connection {
-            action: ConnectionAction::CloseAll { force: false },
+            action: ConnectionAction::Close {
+                legacy_id: None,
+                id: None,
+                all: true,
+                host: None,
+                process: None,
+                force: false,
+            },
         })
         .await
         .expect("close all cancelled");
         run_cli_command(Commands::Connection {
-            action: ConnectionAction::CloseByHost {
-                host: "example".to_string(),
+            action: ConnectionAction::Close {
+                legacy_id: None,
+                id: None,
+                all: false,
+                host: Some("example".to_string()),
+                process: None,
                 force: false,
             },
         })
         .await
         .expect("close by host cancelled");
         run_cli_command(Commands::Connection {
-            action: ConnectionAction::CloseByProcess {
-                process: "curl".to_string(),
+            action: ConnectionAction::Close {
+                legacy_id: None,
+                id: None,
+                all: false,
+                host: None,
+                process: Some("curl".to_string()),
                 force: false,
             },
         })
@@ -961,6 +1010,52 @@ async fn run_cli_command_sets_and_unsets_configs_dir() {
         .await
         .expect("read config.toml after unset");
     assert!(!settings.contains("configs_dir"));
+
+    if let Some(value) = old_home {
+        env::set_var("MIHOMO_HOME", value);
+    } else {
+        env::remove_var("MIHOMO_HOME");
+    }
+}
+
+#[tokio::test]
+async fn run_cli_command_supports_namespaced_version_and_service_commands() {
+    let _guard = env_lock().lock().await;
+
+    let temp = tempdir().expect("create temp dir");
+    let old_home = env::var("MIHOMO_HOME").ok();
+    env::set_var("MIHOMO_HOME", temp.path());
+
+    common::install_fake_version(temp.path(), "v1.2.3").await;
+
+    let cm = ConfigManager::new().expect("config manager");
+    cm.save(
+        "default",
+        "port: 7890\nexternal-controller: 127.0.0.1:9090\n",
+    )
+    .await
+    .expect("write default profile");
+    cm.set_current("default")
+        .await
+        .expect("set default profile current");
+
+    run_cli_command(Commands::Version {
+        action: VersionAction::Use {
+            version: "v1.2.3".to_string(),
+        },
+    })
+    .await
+    .expect("version use");
+    run_cli_command(Commands::Version {
+        action: VersionAction::List,
+    })
+    .await
+    .expect("version list");
+    run_cli_command(Commands::Service {
+        action: ServiceAction::Status,
+    })
+    .await
+    .expect("service status");
 
     if let Some(value) = old_home {
         env::set_var("MIHOMO_HOME", value);

--- a/tests/cli_handlers_spec.rs
+++ b/tests/cli_handlers_spec.rs
@@ -163,6 +163,31 @@ async fn run_cli_command_covers_config_version_and_service_paths() {
     .await
     .expect("config list");
     run_cli_command(Commands::Config {
+        action: ConfigAction::Current,
+    })
+    .await
+    .expect("config current");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Path,
+    })
+    .await
+    .expect("config path");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Set {
+            key: mihomo_rs::cli::ConfigKey::ConfigsDir,
+            value: "icloud/configs".to_string(),
+        },
+    })
+    .await
+    .expect("config set configs-dir");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Unset {
+            key: mihomo_rs::cli::ConfigKey::ConfigsDir,
+        },
+    })
+    .await
+    .expect("config unset configs-dir");
+    run_cli_command(Commands::Config {
         action: ConfigAction::Show {
             profile: Some("default".to_string()),
         },
@@ -765,6 +790,11 @@ async fn run_cli_command_covers_config_and_proxy_empty_branches() {
     })
     .await
     .expect("config list empty");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Path,
+    })
+    .await
+    .expect("config path empty");
 
     // Invalid config.toml makes get_current() fail and triggers show fallback closure.
     tokio::fs::write(temp.path().join("config.toml"), "default = [")
@@ -818,6 +848,119 @@ async fn run_cli_command_covers_config_and_proxy_empty_branches() {
     .expect("proxy current empty");
 
     mock_proxies.assert_async().await;
+
+    if let Some(value) = old_home {
+        env::set_var("MIHOMO_HOME", value);
+    } else {
+        env::remove_var("MIHOMO_HOME");
+    }
+}
+
+#[tokio::test]
+async fn run_cli_command_covers_config_path_empty_state() {
+    let _guard = env_lock().lock().await;
+
+    let temp = tempdir().expect("create temp dir");
+    let old_home = env::var("MIHOMO_HOME").ok();
+    env::set_var("MIHOMO_HOME", temp.path());
+
+    run_cli_command(Commands::Config {
+        action: ConfigAction::List,
+    })
+    .await
+    .expect("config list empty");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Current,
+    })
+    .await
+    .expect("config current empty");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Path,
+    })
+    .await
+    .expect("config path empty");
+
+    if let Some(value) = old_home {
+        env::set_var("MIHOMO_HOME", value);
+    } else {
+        env::remove_var("MIHOMO_HOME");
+    }
+}
+
+#[tokio::test]
+async fn run_cli_command_current_uses_special_character_configs_dir() {
+    let _guard = env_lock().lock().await;
+
+    let temp = tempdir().expect("create temp dir");
+    let old_home = env::var("MIHOMO_HOME").ok();
+    env::set_var("MIHOMO_HOME", temp.path());
+
+    let cm = ConfigManager::new().expect("config manager");
+    cm.set_configs_dir("iCloud Drive/代理配置 (测试) [v2] #1 & team")
+        .await
+        .expect("set special configs dir");
+    cm.save(
+        "default",
+        "port: 7890\nexternal-controller: 127.0.0.1:9090\n",
+    )
+    .await
+    .expect("write default profile");
+    cm.set_current("default")
+        .await
+        .expect("set default current");
+
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Current,
+    })
+    .await
+    .expect("config current with special dir");
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Path,
+    })
+    .await
+    .expect("config path with special dir");
+
+    if let Some(value) = old_home {
+        env::set_var("MIHOMO_HOME", value);
+    } else {
+        env::remove_var("MIHOMO_HOME");
+    }
+}
+
+#[tokio::test]
+async fn run_cli_command_sets_and_unsets_configs_dir() {
+    let _guard = env_lock().lock().await;
+
+    let temp = tempdir().expect("create temp dir");
+    let old_home = env::var("MIHOMO_HOME").ok();
+    env::set_var("MIHOMO_HOME", temp.path());
+
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Set {
+            key: mihomo_rs::cli::ConfigKey::ConfigsDir,
+            value: "iCloud Drive/Clash Configs".to_string(),
+        },
+    })
+    .await
+    .expect("config set configs-dir");
+
+    let settings = tokio::fs::read_to_string(temp.path().join("config.toml"))
+        .await
+        .expect("read config.toml");
+    assert!(settings.contains("configs_dir = \"iCloud Drive/Clash Configs\""));
+
+    run_cli_command(Commands::Config {
+        action: ConfigAction::Unset {
+            key: mihomo_rs::cli::ConfigKey::ConfigsDir,
+        },
+    })
+    .await
+    .expect("config unset configs-dir");
+
+    let settings = tokio::fs::read_to_string(temp.path().join("config.toml"))
+        .await
+        .expect("read config.toml after unset");
+    assert!(!settings.contains("configs_dir"));
 
     if let Some(value) = old_home {
         env::set_var("MIHOMO_HOME", value);

--- a/tests/config_manager_spec.rs
+++ b/tests/config_manager_spec.rs
@@ -203,3 +203,143 @@ async fn get_current_path_tracks_selected_profile_file() {
     let current_path = manager.get_current_path().await.expect("get current path");
     assert_eq!(current_path, home.join("configs/alpha.yaml"));
 }
+
+#[tokio::test]
+async fn custom_configs_dir_in_settings_is_used_for_profile_io() {
+    let temp = setup_temp_home();
+    let home = temp_home_path(&temp);
+    let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+    fs::write(
+        home.join("config.toml"),
+        "[paths]\nconfigs_dir = \"icloud/configs\"\n",
+    )
+    .await
+    .expect("write custom configs dir");
+
+    manager
+        .save("cloud", &default_test_config())
+        .await
+        .expect("save cloud profile");
+    manager
+        .set_current("cloud")
+        .await
+        .expect("set current cloud profile");
+
+    let profiles = manager.list_profiles().await.expect("list profiles");
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0].path, home.join("icloud/configs/cloud.yaml"));
+
+    let current_path = manager.get_current_path().await.expect("get current path");
+    assert_eq!(current_path, home.join("icloud/configs/cloud.yaml"));
+    assert!(home.join("icloud/configs/cloud.yaml").exists());
+}
+
+#[tokio::test]
+async fn set_and_unset_configs_dir_updates_settings_and_preserves_default_profile() {
+    let temp = setup_temp_home();
+    let home = temp_home_path(&temp);
+    let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+    fs::write(home.join("config.toml"), "[default]\nprofile = \"work\"\n")
+        .await
+        .expect("write config with default profile");
+
+    let resolved = manager
+        .set_configs_dir("~/Library/Mobile Documents/mihomo-rs/configs")
+        .await
+        .expect("set configs dir");
+    assert!(resolved.ends_with("Library/Mobile Documents/mihomo-rs/configs"));
+
+    let content = fs::read_to_string(home.join("config.toml"))
+        .await
+        .expect("read config");
+    let config: toml::Value = toml::from_str(&content).expect("parse config");
+    assert_eq!(
+        config
+            .get("default")
+            .and_then(|v| v.get("profile"))
+            .and_then(|v| v.as_str()),
+        Some("work")
+    );
+    assert_eq!(
+        config
+            .get("paths")
+            .and_then(|v| v.get("configs_dir"))
+            .and_then(|v| v.as_str()),
+        Some("~/Library/Mobile Documents/mihomo-rs/configs")
+    );
+
+    let unset_resolved = manager
+        .unset_configs_dir()
+        .await
+        .expect("unset configs dir");
+    assert_eq!(unset_resolved, home.join("configs"));
+
+    let content = fs::read_to_string(home.join("config.toml"))
+        .await
+        .expect("read config after unset");
+    let config: toml::Value = toml::from_str(&content).expect("parse config after unset");
+    assert_eq!(
+        config
+            .get("default")
+            .and_then(|v| v.get("profile"))
+            .and_then(|v| v.as_str()),
+        Some("work")
+    );
+    assert!(config
+        .get("paths")
+        .and_then(|v| v.get("configs_dir"))
+        .is_none());
+}
+
+#[tokio::test]
+async fn set_configs_dir_rejects_empty_path() {
+    let temp = setup_temp_home();
+    let home = temp_home_path(&temp);
+    let manager = ConfigManager::with_home(home).expect("create config manager");
+
+    let err = manager
+        .set_configs_dir("   ")
+        .await
+        .expect_err("empty path should fail");
+    assert!(matches!(err, MihomoError::Config(_)));
+}
+
+#[tokio::test]
+async fn special_character_configs_dir_roundtrips_and_updates_current_path() {
+    let temp = setup_temp_home();
+    let home = temp_home_path(&temp);
+    let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+    let special_path = "iCloud Drive/代理配置 (测试) [v2] #1 & team";
+    let resolved = manager
+        .set_configs_dir(special_path)
+        .await
+        .expect("set special configs dir");
+    assert_eq!(resolved, home.join(special_path));
+
+    manager
+        .save("alpha", &default_test_config())
+        .await
+        .expect("save alpha in special dir");
+    manager
+        .set_current("alpha")
+        .await
+        .expect("set alpha current");
+
+    let current_path = manager.get_current_path().await.expect("get current path");
+    assert_eq!(current_path, home.join(special_path).join("alpha.yaml"));
+
+    let content = fs::read_to_string(home.join("config.toml"))
+        .await
+        .expect("read config with special path");
+    let config: toml::Value = toml::from_str(&content).expect("parse config with special path");
+    assert_eq!(
+        config
+            .get("paths")
+            .and_then(|v| v.get("configs_dir"))
+            .and_then(|v| v.as_str()),
+        Some(special_path)
+    );
+}


### PR DESCRIPTION
## Summary
- add configurable profile storage support via `configs-dir`, including `config current`, `config path`, `config set`, and `config unset`
- reorganize the CLI around clearer namespaced command groups for version, service, proxy, and connection workflows while keeping legacy aliases compatible
- fix CI regressions by addressing new clippy warnings, updating `rustls-webpki`, and stabilizing config-related tests

## Highlights
- support storing config profiles in iCloud or other cloud-synced directories without moving the full mihomo-rs home
- improve CLI help and README guidance so recommended commands are clearer and legacy compatibility stays non-breaking
- keep special-character config paths working, including spaces, Chinese, brackets, `#`, and `&`
- harden CI by fixing clippy fallout from newer toolchains and reducing config test flakiness from environment and port assumptions

## Testing
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit --no-fetch
- cargo test unit_module_profile_lifecycle_hits_file_branches -- --nocapture
- cargo test resolve_config_dir_ -- --nocapture --test-threads=1