### PR TITLE
Fix review issues for config path and connection host filters

### DIFF
--- a/src/cli/handlers/connection.rs
+++ b/src/cli/handlers/connection.rs
@@ -134,7 +134,9 @@ async fn load_connections(
 ) -> crate::core::Result<Vec<Connection>> {
     let mut connections = conn_mgr.list().await?;
     if let Some(host_filter) = host {
-        connections.retain(|c| c.metadata.host.contains(host_filter));
+        connections.retain(|c| {
+            c.metadata.host.contains(host_filter) || c.metadata.destination_ip.contains(host_filter)
+        });
     }
     if let Some(process_filter) = process {
         connections.retain(|c| c.metadata.process_path.contains(process_filter));

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -192,7 +192,7 @@ impl ConfigManager {
 
     pub async fn set_configs_dir(&self, path: &str) -> Result<PathBuf> {
         let trimmed = path.trim();
-        let _ = self.normalize_configs_dir(trimmed)?;
+        let normalized = self.normalize_configs_dir(trimmed)?;
 
         let mut config = self.read_settings_value().await?;
         if let toml::Value::Table(ref mut table) = config {
@@ -209,7 +209,7 @@ impl ConfigManager {
         }
 
         self.write_settings_value(&config).await?;
-        self.resolve_config_dir()
+        Ok(normalized)
     }
 
     pub async fn unset_configs_dir(&self) -> Result<PathBuf> {
@@ -228,7 +228,7 @@ impl ConfigManager {
         }
 
         self.write_settings_value(&config).await?;
-        self.resolve_config_dir()
+        Ok(self.config_dir.clone())
     }
 
     pub async fn load(&self, profile: &str) -> Result<String> {

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -31,7 +31,7 @@ impl ConnectionManager {
         let connections = self.list().await?;
         let filtered: Vec<Connection> = connections
             .into_iter()
-            .filter(|c| c.metadata.host.contains(host))
+            .filter(|c| matches_host_filter(c, host))
             .collect();
         log::debug!(
             "Filtered {} connections matching host '{}'",
@@ -103,6 +103,11 @@ impl ConnectionManager {
     }
 }
 
+fn matches_host_filter(connection: &Connection, host_filter: &str) -> bool {
+    connection.metadata.host.contains(host_filter)
+        || connection.metadata.destination_ip.contains(host_filter)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,6 +159,17 @@ mod tests {
         assert_eq!(conn.download, 2048);
     }
 
+    #[test]
+    fn host_filter_matches_host_or_destination_ip() {
+        let by_host = create_test_connection("by-host", "example.com", "/usr/bin/app", "DIRECT");
+        let mut by_ip = create_test_connection("by-ip", "", "/usr/bin/app", "DIRECT");
+        by_ip.metadata.destination_ip = "4.4.4.4".to_string();
+
+        assert!(matches_host_filter(&by_host, "example"));
+        assert!(matches_host_filter(&by_ip, "4.4.4"));
+        assert!(!matches_host_filter(&by_ip, "example"));
+    }
+
     #[tokio::test]
     async fn test_manager_methods_with_mock_server() {
         let mut server = Server::new_async().await;
@@ -187,6 +203,7 @@ mod tests {
             manager.filter_by_host("example").await.expect("host").len(),
             1
         );
+        assert_eq!(manager.filter_by_host("1.1.1").await.expect("ip").len(), 1);
         assert_eq!(
             manager
                 .filter_by_process("Safari")

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -180,7 +180,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(payload)
-            .expect(7)
+            .expect(8)
             .create_async()
             .await;
         let close_mock = server

--- a/tests/cli_handlers_spec.rs
+++ b/tests/cli_handlers_spec.rs
@@ -644,7 +644,13 @@ async fn run_cli_command_covers_connection_stream_and_empty_branches() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(edge_connections)
-        .expect(2)
+        .expect(5)
+        .create_async()
+        .await;
+    let close_edge = server
+        .mock("DELETE", "/connections/abc123456789")
+        .with_status(204)
+        .expect(1)
         .create_async()
         .await;
 
@@ -702,6 +708,21 @@ async fn run_cli_command_covers_connection_stream_and_empty_branches() {
     })
     .await
     .expect("connection filter process edge payload");
+    run_cli_command(Commands::Connection {
+        action: ConnectionAction::FilterHost {
+            host: "4.4.4.4".to_string(),
+        },
+    })
+    .await
+    .expect("connection filter host by ip");
+    run_cli_command(Commands::Connection {
+        action: ConnectionAction::CloseByHost {
+            host: "4.4.4.4".to_string(),
+            force: true,
+        },
+    })
+    .await
+    .expect("connection close by ip");
 
     // Stream one snapshot then close to exercise stream rendering branches.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -739,6 +760,7 @@ async fn run_cli_command_covers_connection_stream_and_empty_branches() {
 
     mock_empty.assert_async().await;
     mock_edge.assert_async().await;
+    close_edge.assert_async().await;
 
     if let Some(value) = old_home {
         env::set_var("MIHOMO_HOME", value);

--- a/tests/config_manager_spec.rs
+++ b/tests/config_manager_spec.rs
@@ -294,6 +294,34 @@ async fn set_and_unset_configs_dir_updates_settings_and_preserves_default_profil
 }
 
 #[tokio::test]
+async fn set_and_unset_configs_dir_return_stored_paths_even_when_env_override_exists() {
+    let temp = setup_temp_home();
+    let home = temp_home_path(&temp);
+    let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
+
+    let old_value = std::env::var("MIHOMO_CONFIGS_DIR").ok();
+    std::env::set_var("MIHOMO_CONFIGS_DIR", home.join("env-override"));
+
+    let resolved = manager
+        .set_configs_dir("icloud/configs")
+        .await
+        .expect("set configs dir");
+    assert_eq!(resolved, home.join("icloud/configs"));
+
+    let unset_resolved = manager
+        .unset_configs_dir()
+        .await
+        .expect("unset configs dir");
+    assert_eq!(unset_resolved, home.join("configs"));
+
+    if let Some(value) = old_value {
+        std::env::set_var("MIHOMO_CONFIGS_DIR", value);
+    } else {
+        std::env::remove_var("MIHOMO_CONFIGS_DIR");
+    }
+}
+
+#[tokio::test]
 async fn set_configs_dir_rejects_empty_path() {
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);

--- a/tests/config_manager_spec.rs
+++ b/tests/config_manager_spec.rs
@@ -2,7 +2,14 @@ mod common;
 
 use common::{config_without_controller, default_test_config, setup_temp_home, temp_home_path};
 use mihomo_rs::{ConfigManager, MihomoError};
+use std::sync::OnceLock;
 use tokio::fs;
+use tokio::sync::Mutex;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn external_controller_of(content: &str) -> Option<String> {
     let value: serde_yaml::Value = serde_yaml::from_str(content).ok()?;
@@ -14,6 +21,8 @@ fn external_controller_of(content: &str) -> Option<String> {
 
 #[tokio::test]
 async fn profile_lifecycle_save_load_list_set_current() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home).expect("create config manager");
@@ -42,6 +51,8 @@ async fn profile_lifecycle_save_load_list_set_current() {
 
 #[tokio::test]
 async fn delete_profile_rejects_active_profile() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home).expect("create config manager");
@@ -67,6 +78,8 @@ async fn delete_profile_rejects_active_profile() {
 
 #[tokio::test]
 async fn ensure_default_config_creates_missing_profile_file() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home).expect("create config manager");
@@ -86,6 +99,8 @@ async fn ensure_default_config_creates_missing_profile_file() {
 
 #[tokio::test]
 async fn external_controller_normalization_and_preserve_unix_socket() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home).expect("create config manager");
@@ -132,6 +147,8 @@ external-controller: /var/run/mihomo.sock
 
 #[tokio::test]
 async fn ensure_external_controller_adds_missing_value() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home).expect("create config manager");
@@ -160,6 +177,8 @@ async fn ensure_external_controller_adds_missing_value() {
 
 #[tokio::test]
 async fn invalid_yaml_and_invalid_settings_file_return_errors() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -187,6 +206,8 @@ async fn invalid_yaml_and_invalid_settings_file_return_errors() {
 
 #[tokio::test]
 async fn get_current_path_tracks_selected_profile_file() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -206,6 +227,8 @@ async fn get_current_path_tracks_selected_profile_file() {
 
 #[tokio::test]
 async fn custom_configs_dir_in_settings_is_used_for_profile_io() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -237,6 +260,8 @@ async fn custom_configs_dir_in_settings_is_used_for_profile_io() {
 
 #[tokio::test]
 async fn set_and_unset_configs_dir_updates_settings_and_preserves_default_profile() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -295,6 +320,8 @@ async fn set_and_unset_configs_dir_updates_settings_and_preserves_default_profil
 
 #[tokio::test]
 async fn set_and_unset_configs_dir_return_stored_paths_even_when_env_override_exists() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home.clone()).expect("create config manager");
@@ -323,6 +350,8 @@ async fn set_and_unset_configs_dir_return_stored_paths_even_when_env_override_ex
 
 #[tokio::test]
 async fn set_configs_dir_rejects_empty_path() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home).expect("create config manager");
@@ -336,6 +365,8 @@ async fn set_configs_dir_rejects_empty_path() {
 
 #[tokio::test]
 async fn special_character_configs_dir_roundtrips_and_updates_current_path() {
+    let _guard = env_lock().lock().await;
+
     let temp = setup_temp_home();
     let home = temp_home_path(&temp);
     let manager = ConfigManager::with_home(home.clone()).expect("create config manager");

--- a/tests/connection_manager_spec.rs
+++ b/tests/connection_manager_spec.rs
@@ -40,7 +40,7 @@ async fn filter_methods_match_expected_connections() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(common::mock_connections_payload())
-        .expect(3)
+        .expect(4)
         .create_async()
         .await;
 
@@ -51,6 +51,10 @@ async fn filter_methods_match_expected_connections() {
         .filter_by_host("example")
         .await
         .expect("filter by host");
+    let by_ip = manager
+        .filter_by_host("8.8.8.8")
+        .await
+        .expect("filter by ip");
     let by_process = manager
         .filter_by_process("Firefox")
         .await
@@ -64,6 +68,8 @@ async fn filter_methods_match_expected_connections() {
 
     assert_eq!(by_host.len(), 1);
     assert_eq!(by_host[0].id, "c1");
+    assert_eq!(by_ip.len(), 1);
+    assert_eq!(by_ip[0].id, "c2");
 
     assert_eq!(by_process.len(), 1);
     assert_eq!(by_process[0].id, "c2");


### PR DESCRIPTION
## Summary
- fix config set/unset so success output reflects the path stored in config.toml even when MIHOMO_CONFIGS_DIR is set
- make connection host filtering match destination IPs as well as host names
- add targeted regression coverage for both review findings

## Testing
- cargo test set_and_unset_configs_dir_return_stored_paths_even_when_env_override_exists -- --nocapture
- cargo test filter_methods_match_expected_connections -- --nocapture
- cargo test run_cli_command_covers_connection_stream_and_empty_branches -- --nocapture
- cargo fmt --check