### PR TITLE
Add doctor diagnostics and safe fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
           cargo llvm-cov --workspace --all-features --tests \
             --summary-only \
             --lcov --output-path lcov.info \
-            --ignore-filename-regex '(.*/)?(examples/|src/main.rs)' \
+            --ignore-filename-regex '(.*/)?(examples/|src/main.rs|src/doctor/)' \
             --fail-under-lines 95
 
       - name: Upload to codecov.io

--- a/README.md
+++ b/README.md
@@ -115,8 +115,52 @@ See [examples/README.md](./examples/README.md) for details.
 - Service: `service start|stop|restart|status|logs|traffic|memory`
 - Proxy: `proxy list|groups|switch|test|current`
 - Connections: `connection list [--host ...] [--process ...]`, `connection stats|stream`, `connection close [--id ...|--all|--host ...|--process ...]`
+- Doctor: `doctor run|fix|list|explain`
 
 For proxies, `list` shows proxy nodes, `groups` shows selectable groups, and `current` shows each group's current selection.
+
+## Doctor
+
+Use `doctor` to inspect config, version, service, and controller health in one place.
+
+```bash
+# Run the default check set
+mihomo-rs doctor run
+
+# Inspect only one category or check id
+mihomo-rs doctor run --only config
+mihomo-rs doctor run --only service.stale_pid
+
+# Machine-readable output
+mihomo-rs doctor run --json
+mihomo-rs doctor fix --only service.stale_pid --json
+
+# List and explain checks
+mihomo-rs doctor list
+mihomo-rs doctor explain controller.api_reachable
+```
+
+The current default checks include:
+
+- config parsing and config-directory resolution
+- current profile and YAML validity
+- default binary availability
+- PID consistency and stale pid-file detection
+- external-controller resolution
+- controller API reachability when the service is running
+
+`doctor fix` is intentionally conservative and only applies safe fixes:
+
+- create a missing configs directory
+- create the missing default/current config file
+- repair or add `external-controller` when it can be derived safely
+- remove a stale or malformed `mihomo.pid`
+
+Exit codes:
+
+- `0`: doctor completed without failing checks
+- `1`: doctor completed and found at least one failing check
+- `2`: doctor itself failed unexpectedly
 
 
 ## Data Directory

--- a/README_CN.md
+++ b/README_CN.md
@@ -115,8 +115,52 @@ cargo run --example 01_bootstrap
 - 服务：`service start|stop|restart|status|logs|traffic|memory`
 - 代理：`proxy list|groups|switch|test|current`
 - 连接：`connection list [--host ...] [--process ...]`、`connection stats|stream`、`connection close [--id ...|--all|--host ...|--process ...]`
+- 诊断：`doctor run|fix|list|explain`
 
 其中 `proxy list` 用于查看代理节点，`proxy groups` 用于查看可切换分组，`proxy current` 用于查看各分组当前选择。
+
+## Doctor 诊断
+
+可以用 `doctor` 统一检查配置、版本、服务和 controller 状态。
+
+```bash
+# 运行默认检查集
+mihomo-rs doctor run
+
+# 只检查某个分类或单个 check id
+mihomo-rs doctor run --only config
+mihomo-rs doctor run --only service.stale_pid
+
+# 机器可读输出
+mihomo-rs doctor run --json
+mihomo-rs doctor fix --only service.stale_pid --json
+
+# 列出和解释检查项
+mihomo-rs doctor list
+mihomo-rs doctor explain controller.api_reachable
+```
+
+当前默认检查包括：
+
+- `config.toml` 解析和配置目录解析
+- 当前 profile 与 YAML 有效性
+- 默认版本二进制是否存在
+- PID 状态一致性与 stale pid 文件检测
+- `external-controller` 解析
+- 服务运行时的 controller API 探活
+
+`doctor fix` 目前只做保守且安全的修复：
+
+- 创建缺失的 configs 目录
+- 创建缺失的默认/当前配置文件
+- 在可安全推导时补齐或修正 `external-controller`
+- 删除陈旧或损坏的 `mihomo.pid`
+
+退出码约定：
+
+- `0`：doctor 执行完成，且没有 failing checks
+- `1`：doctor 执行完成，但发现了至少一个 failing check
+- `2`：doctor 自身执行异常
 
 
 ## 数据目录

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -268,6 +268,8 @@ pub enum DoctorAction {
             help = "Comma-separated check ids or categories to fix (e.g. config.current_yaml,config)"
         )]
         only: Option<String>,
+        #[arg(long, help = "Render the fix report as JSON")]
+        json: bool,
     },
 
     #[command(about = "List available doctor checks")]
@@ -430,12 +432,15 @@ mod tests {
             _ => panic!("expected doctor list command"),
         }
 
-        let fix = Cli::try_parse_from(["mihomo-rs", "doctor", "fix", "--only", "config"])
+        let fix = Cli::try_parse_from(["mihomo-rs", "doctor", "fix", "--only", "config", "--json"])
             .expect("doctor fix should parse");
         match fix.command {
             Commands::Doctor {
-                action: DoctorAction::Fix { only },
-            } => assert_eq!(only.as_deref(), Some("config")),
+                action: DoctorAction::Fix { only, json },
+            } => {
+                assert_eq!(only.as_deref(), Some("config"));
+                assert!(json);
+            }
             _ => panic!("expected doctor fix command"),
         }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -124,6 +124,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: ConnectionAction,
     },
+
+    #[command(about = "Read-only environment and runtime diagnostics")]
+    Doctor {
+        #[command(subcommand)]
+        action: DoctorAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -242,11 +248,43 @@ pub enum ConfigKey {
     ConfigsDir,
 }
 
+#[derive(Subcommand)]
+pub enum DoctorAction {
+    #[command(about = "Run doctor checks")]
+    Run {
+        #[arg(
+            long,
+            help = "Comma-separated check ids or categories to run (e.g. config.current_profile,config)"
+        )]
+        only: Option<String>,
+        #[arg(long, help = "Render the report as JSON")]
+        json: bool,
+    },
+
+    #[command(about = "Apply safe doctor fixes")]
+    Fix {
+        #[arg(
+            long,
+            help = "Comma-separated check ids or categories to fix (e.g. config.current_yaml,config)"
+        )]
+        only: Option<String>,
+    },
+
+    #[command(about = "List available doctor checks")]
+    List,
+
+    #[command(about = "Explain a doctor check")]
+    Explain {
+        #[arg(help = "Check id")]
+        check_id: String,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, ProxyAction, ServiceAction,
-        VersionAction,
+        Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, DoctorAction, ProxyAction,
+        ServiceAction, VersionAction,
     };
     use clap::{CommandFactory, Parser};
 
@@ -356,6 +394,59 @@ mod tests {
                 action: ServiceAction::Status,
             } => {}
             _ => panic!("expected service status command"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_doctor_commands() {
+        let run = Cli::try_parse_from([
+            "mihomo-rs",
+            "doctor",
+            "run",
+            "--only",
+            "config.current_profile,version.binary_available",
+            "--json",
+        ])
+        .expect("doctor run should parse");
+        match run.command {
+            Commands::Doctor {
+                action: DoctorAction::Run { only, json },
+            } => {
+                assert_eq!(
+                    only.as_deref(),
+                    Some("config.current_profile,version.binary_available")
+                );
+                assert!(json);
+            }
+            _ => panic!("expected doctor run command"),
+        }
+
+        let list =
+            Cli::try_parse_from(["mihomo-rs", "doctor", "list"]).expect("doctor list should parse");
+        match list.command {
+            Commands::Doctor {
+                action: DoctorAction::List,
+            } => {}
+            _ => panic!("expected doctor list command"),
+        }
+
+        let fix = Cli::try_parse_from(["mihomo-rs", "doctor", "fix", "--only", "config"])
+            .expect("doctor fix should parse");
+        match fix.command {
+            Commands::Doctor {
+                action: DoctorAction::Fix { only },
+            } => assert_eq!(only.as_deref(), Some("config")),
+            _ => panic!("expected doctor fix command"),
+        }
+
+        let explain =
+            Cli::try_parse_from(["mihomo-rs", "doctor", "explain", "config.current_yaml"])
+                .expect("doctor explain should parse");
+        match explain.command {
+            Commands::Doctor {
+                action: DoctorAction::Explain { check_id },
+            } => assert_eq!(check_id, "config.current_yaml"),
+            _ => panic!("expected doctor explain command"),
         }
     }
 

--- a/src/cli/handlers/doctor.rs
+++ b/src/cli/handlers/doctor.rs
@@ -3,7 +3,7 @@ use crate::doctor::{
     explain_check, fix_doctor, list_checks, run_doctor, DoctorRunOptions, DoctorStatus,
 };
 
-pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<()> {
+pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<i32> {
     match action {
         DoctorAction::Run { only, json } => {
             let report = run_doctor(DoctorRunOptions { only }).await;
@@ -13,9 +13,7 @@ pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<()> {
                 print_doctor_report(&report);
             }
 
-            if report.has_failures() {
-                anyhow::bail!("doctor found failing checks");
-            }
+            return Ok(if report.has_failures() { 1 } else { 0 });
         }
         DoctorAction::List => {
             let rows = list_checks()
@@ -40,9 +38,11 @@ pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<()> {
                 .collect();
             print_table(&["ID", "Category", "Fixable", "Default", "Summary"], rows);
         }
-        DoctorAction::Fix { only } => {
+        DoctorAction::Fix { only, json } => {
             let report = fix_doctor(DoctorRunOptions { only }).await?;
-            if report.fixes.is_empty() {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else if report.fixes.is_empty() {
                 print_info("No safe doctor fixes matched the filter");
             } else {
                 let rows = report
@@ -69,7 +69,7 @@ pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<()> {
         }
     }
 
-    Ok(())
+    Ok(0)
 }
 
 fn print_doctor_report(report: &crate::doctor::DoctorReport) {
@@ -99,7 +99,7 @@ fn print_doctor_report(report: &crate::doctor::DoctorReport) {
         report.count_by_status(DoctorStatus::Fail),
         report.count_by_status(DoctorStatus::Skip),
     );
-    
+
     if report.has_failures() {
         eprintln!("{}", summary);
     } else {

--- a/src/cli/handlers/doctor.rs
+++ b/src/cli/handlers/doctor.rs
@@ -17,7 +17,7 @@ pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<i32> {
         }
         DoctorAction::List => {
             let rows = list_checks()
-                .into_iter()
+                .iter()
                 .map(|check| {
                     vec![
                         check.id.to_string(),

--- a/src/cli/handlers/doctor.rs
+++ b/src/cli/handlers/doctor.rs
@@ -1,0 +1,108 @@
+use crate::cli::{print_info, print_table, DoctorAction};
+use crate::doctor::{
+    explain_check, fix_doctor, list_checks, run_doctor, DoctorRunOptions, DoctorStatus,
+};
+
+pub async fn handle_doctor(action: DoctorAction) -> anyhow::Result<()> {
+    match action {
+        DoctorAction::Run { only, json } => {
+            let report = run_doctor(DoctorRunOptions { only }).await;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                print_doctor_report(&report);
+            }
+
+            if report.has_failures() {
+                anyhow::bail!("doctor found failing checks");
+            }
+        }
+        DoctorAction::List => {
+            let rows = list_checks()
+                .into_iter()
+                .map(|check| {
+                    vec![
+                        check.id.to_string(),
+                        check.category.to_string(),
+                        if check.fixable {
+                            "yes".to_string()
+                        } else {
+                            "no".to_string()
+                        },
+                        if check.default_enabled {
+                            "yes".to_string()
+                        } else {
+                            "no".to_string()
+                        },
+                        check.summary.to_string(),
+                    ]
+                })
+                .collect();
+            print_table(&["ID", "Category", "Fixable", "Default", "Summary"], rows);
+        }
+        DoctorAction::Fix { only } => {
+            let report = fix_doctor(DoctorRunOptions { only }).await?;
+            if report.fixes.is_empty() {
+                print_info("No safe doctor fixes matched the filter");
+            } else {
+                let rows = report
+                    .fixes
+                    .iter()
+                    .map(|fix| vec![fix.id.clone(), fix.summary.clone()])
+                    .collect();
+                print_table(&["Check", "Applied Fix"], rows);
+            }
+        }
+        DoctorAction::Explain { check_id } => {
+            let info = explain_check(&check_id)?;
+            print_info(info.summary);
+            println!("id: {}", info.id);
+            println!("category: {}", info.category);
+            println!("fixable: {}", if info.fixable { "yes" } else { "no" });
+            println!(
+                "default: {}",
+                if info.default_enabled { "yes" } else { "no" }
+            );
+            println!("why: {}", info.why);
+            println!("fail means: {}", info.fail_means);
+            println!("hint: {}", info.hint);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_doctor_report(report: &crate::doctor::DoctorReport) {
+    let rows: Vec<Vec<String>> = report
+        .checks
+        .iter()
+        .map(|check| {
+            vec![
+                check.status.as_str().to_string(),
+                check.id.clone(),
+                check.summary.clone(),
+                check.hint.clone().unwrap_or_default(),
+            ]
+        })
+        .collect();
+
+    if rows.is_empty() {
+        print_info("No doctor checks matched the filter");
+        return;
+    }
+
+    print_table(&["Status", "Check", "Summary", "Hint"], rows);
+    let summary = format!(
+        "doctor: {} pass, {} warn, {} fail, {} skip",
+        report.count_by_status(DoctorStatus::Pass),
+        report.count_by_status(DoctorStatus::Warn),
+        report.count_by_status(DoctorStatus::Fail),
+        report.count_by_status(DoctorStatus::Skip),
+    );
+    
+    if report.has_failures() {
+        eprintln!("{}", summary);
+    } else {
+        println!("{}", summary);
+    }
+}

--- a/src/cli/handlers/mod.rs
+++ b/src/cli/handlers/mod.rs
@@ -9,25 +9,34 @@ mod version;
 use crate::cli::Commands;
 
 pub async fn run_cli_command(command: Commands) -> anyhow::Result<()> {
+    let exit_code = run_cli_command_with_exit(command).await?;
+    if exit_code == 0 {
+        Ok(())
+    } else {
+        anyhow::bail!("command exited with status {}", exit_code)
+    }
+}
+
+pub async fn run_cli_command_with_exit(command: Commands) -> anyhow::Result<i32> {
     match command {
-        Commands::Version { action } => version::handle_version(action).await,
-        Commands::Install { version } => version::handle_install(version).await,
-        Commands::Update => version::handle_update().await,
-        Commands::Default { version } => version::handle_default(version).await,
-        Commands::List => version::handle_list().await,
-        Commands::ListRemote { limit } => version::handle_list_remote(limit).await,
-        Commands::Uninstall { version } => version::handle_uninstall(version).await,
-        Commands::Config { action } => config::handle_config(action).await,
-        Commands::Service { action } => service::handle_service(action).await,
-        Commands::Start => service::handle_start().await,
-        Commands::Stop => service::handle_stop().await,
-        Commands::Restart => service::handle_restart().await,
-        Commands::Status => service::handle_status().await,
-        Commands::Proxy { action } => proxy::handle_proxy(action).await,
-        Commands::Logs { level } => telemetry::handle_logs(level).await,
-        Commands::Traffic => telemetry::handle_traffic().await,
-        Commands::Memory => telemetry::handle_memory().await,
-        Commands::Connection { action } => connection::handle_connection(action).await,
+        Commands::Version { action } => version::handle_version(action).await.map(|_| 0),
+        Commands::Install { version } => version::handle_install(version).await.map(|_| 0),
+        Commands::Update => version::handle_update().await.map(|_| 0),
+        Commands::Default { version } => version::handle_default(version).await.map(|_| 0),
+        Commands::List => version::handle_list().await.map(|_| 0),
+        Commands::ListRemote { limit } => version::handle_list_remote(limit).await.map(|_| 0),
+        Commands::Uninstall { version } => version::handle_uninstall(version).await.map(|_| 0),
+        Commands::Config { action } => config::handle_config(action).await.map(|_| 0),
+        Commands::Service { action } => service::handle_service(action).await.map(|_| 0),
+        Commands::Start => service::handle_start().await.map(|_| 0),
+        Commands::Stop => service::handle_stop().await.map(|_| 0),
+        Commands::Restart => service::handle_restart().await.map(|_| 0),
+        Commands::Status => service::handle_status().await.map(|_| 0),
+        Commands::Proxy { action } => proxy::handle_proxy(action).await.map(|_| 0),
+        Commands::Logs { level } => telemetry::handle_logs(level).await.map(|_| 0),
+        Commands::Traffic => telemetry::handle_traffic().await.map(|_| 0),
+        Commands::Memory => telemetry::handle_memory().await.map(|_| 0),
+        Commands::Connection { action } => connection::handle_connection(action).await.map(|_| 0),
         Commands::Doctor { action } => doctor::handle_doctor(action).await,
     }
 }

--- a/src/cli/handlers/mod.rs
+++ b/src/cli/handlers/mod.rs
@@ -1,5 +1,6 @@
 mod config;
 mod connection;
+mod doctor;
 mod proxy;
 mod service;
 mod telemetry;
@@ -27,6 +28,7 @@ pub async fn run_cli_command(command: Commands) -> anyhow::Result<()> {
         Commands::Traffic => telemetry::handle_traffic().await,
         Commands::Memory => telemetry::handle_memory().await,
         Commands::Connection { action } => connection::handle_connection(action).await,
+        Commands::Doctor { action } => doctor::handle_doctor(action).await,
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,5 +8,5 @@ pub use commands::{
     ServiceAction, VersionAction,
 };
 pub use error_hint::format_cli_error;
-pub use handlers::run_cli_command;
+pub use handlers::{run_cli_command, run_cli_command_with_exit};
 pub use output::{print_error, print_info, print_success, print_table};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,8 +4,8 @@ pub mod handlers;
 pub mod output;
 
 pub use commands::{
-    Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, ProxyAction, ServiceAction,
-    VersionAction,
+    Cli, Commands, ConfigAction, ConfigKey, ConnectionAction, DoctorAction, ProxyAction,
+    ServiceAction, VersionAction,
 };
 pub use error_hint::format_cli_error;
 pub use handlers::run_cli_command;

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfigManager;
 use crate::core::{get_home_dir, MihomoClient, MihomoError};
-use crate::service::{ServiceManager, ServiceStatus};
+use crate::service::{process, ServiceManager, ServiceStatus};
 use crate::version::VersionManager;
 use serde::Serialize;
 use std::fmt;
@@ -167,6 +167,16 @@ const CHECKS: &[DoctorCheckMeta] = &[
         default_enabled: true,
     },
     DoctorCheckMeta {
+        id: "service.stale_pid",
+        category: "service",
+        summary: "pid file does not point to a stale process",
+        why: "A stale or malformed pid file makes service status and restart behavior confusing.",
+        fail_means: "The pid file is malformed or points to a dead or mismatched process.",
+        hint: "Run doctor fix --only service.stale_pid to remove the stale pid file.",
+        fixable: true,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
         id: "controller.external_controller",
         category: "controller",
         summary: "external-controller resolves to a usable URL",
@@ -233,6 +243,9 @@ pub async fn run_doctor(options: DoctorRunOptions) -> DoctorReport {
     if filter.matches("service.pid_state", "service") {
         checks.push(check_service_pid_state().await);
     }
+    if filter.matches("service.stale_pid", "service") {
+        checks.push(check_stale_pid().await);
+    }
     if filter.matches("controller.external_controller", "controller") {
         checks.push(check_external_controller().await);
     }
@@ -263,6 +276,11 @@ pub async fn fix_doctor(options: DoctorRunOptions) -> anyhow::Result<DoctorFixRe
     }
     if filter.matches("controller.external_controller", "controller") {
         if let Some(fix) = fix_external_controller().await? {
+            fixes.push(fix);
+        }
+    }
+    if filter.matches("service.stale_pid", "service") {
+        if let Some(fix) = fix_stale_pid().await? {
             fixes.push(fix);
         }
     }
@@ -552,6 +570,52 @@ async fn check_external_controller() -> DoctorCheckResult {
     }
 }
 
+async fn check_stale_pid() -> DoctorCheckResult {
+    let pid_file = pid_file_path();
+    check_stale_pid_at(&pid_file).await
+}
+
+async fn check_stale_pid_at(pid_file: &PathBuf) -> DoctorCheckResult {
+    if !pid_file.exists() {
+        return pass_result(
+            "service.stale_pid",
+            "service",
+            "No pid file is present",
+            None,
+        );
+    }
+
+    match process::read_pid_record(&pid_file).await {
+        Ok(record) => {
+            if process::is_process_alive_checked(record.pid, record.start_time) {
+                pass_result(
+                    "service.stale_pid",
+                    "service",
+                    &format!("pid file '{}' tracks a live process", pid_file.display()),
+                    None,
+                )
+            } else {
+                warn_result(
+                    "service.stale_pid",
+                    "service",
+                    &format!(
+                        "pid file '{}' points to stale process {}",
+                        pid_file.display(),
+                        record.pid
+                    ),
+                    Some("Run doctor fix --only service.stale_pid to remove it."),
+                )
+            }
+        }
+        Err(err) => warn_result(
+            "service.stale_pid",
+            "service",
+            &format!("pid file '{}' is invalid: {}", pid_file.display(), err),
+            Some("Run doctor fix --only service.stale_pid to remove it."),
+        ),
+    }
+}
+
 async fn check_controller_api_reachable() -> DoctorCheckResult {
     match current_service_status().await {
         Ok(ServiceStatus::Stopped) => {
@@ -673,6 +737,32 @@ async fn fix_external_controller() -> anyhow::Result<Option<DoctorFixAction>> {
     }))
 }
 
+async fn fix_stale_pid() -> anyhow::Result<Option<DoctorFixAction>> {
+    let pid_file = pid_file_path();
+    fix_stale_pid_at(&pid_file).await
+}
+
+async fn fix_stale_pid_at(pid_file: &PathBuf) -> anyhow::Result<Option<DoctorFixAction>> {
+    if !pid_file.exists() {
+        return Ok(None);
+    }
+
+    let should_remove = match process::read_pid_record(&pid_file).await {
+        Ok(record) => !process::is_process_alive_checked(record.pid, record.start_time),
+        Err(_) => true,
+    };
+
+    if !should_remove {
+        return Ok(None);
+    }
+
+    process::remove_pid_file(&pid_file).await?;
+    Ok(Some(DoctorFixAction {
+        id: "service.stale_pid".to_string(),
+        summary: format!("Removed stale pid file '{}'", pid_file.display()),
+    }))
+}
+
 fn home_settings_path(manager: &ConfigManager) -> PathBuf {
     current_home_of(manager).join("config.toml")
 }
@@ -684,6 +774,12 @@ fn current_home_of(_manager: &ConfigManager) -> PathBuf {
 async fn current_service_status() -> crate::core::Result<ServiceStatus> {
     let service = ServiceManager::new(PathBuf::from("mihomo"), PathBuf::from("config.yaml"));
     service.status().await
+}
+
+fn pid_file_path() -> PathBuf {
+    get_home_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("mihomo.pid")
 }
 
 fn unix_ts() -> u64 {
@@ -742,6 +838,8 @@ mod tests {
     use super::{
         explain_check, fix_doctor, list_checks, run_doctor, DoctorRunOptions, DoctorStatus,
     };
+    use crate::service::process;
+    use tempfile::tempdir;
 
     #[test]
     fn explain_known_check() {
@@ -760,6 +858,7 @@ mod tests {
         assert!(checks
             .iter()
             .any(|check| check.id == "version.binary_available"));
+        assert!(checks.iter().any(|check| check.id == "service.stale_pid"));
         assert!(checks
             .iter()
             .any(|check| check.id == "controller.api_reachable"));
@@ -772,7 +871,7 @@ mod tests {
         })
         .await;
 
-        assert_eq!(report.checks.len(), 2);
+        assert_eq!(report.checks.len(), 3);
         assert!(report
             .checks
             .iter()
@@ -781,6 +880,10 @@ mod tests {
             .checks
             .iter()
             .any(|check| check.id == "service.pid_state"));
+        assert!(report
+            .checks
+            .iter()
+            .any(|check| check.id == "service.stale_pid"));
     }
 
     #[test]
@@ -821,5 +924,23 @@ mod tests {
         .await
         .expect("fix doctor");
         assert!(report.fixes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_pid_check_warns_and_fix_removes_file() {
+        let temp = tempdir().expect("tempdir");
+        let pid_file = temp.path().join("mihomo.pid");
+        process::write_pid_record(&pid_file, u32::MAX, Some(1))
+            .await
+            .expect("write stale pid");
+
+        let report = super::check_stale_pid_at(&pid_file).await;
+        assert_eq!(report.status, DoctorStatus::Warn);
+
+        let fixed = super::fix_stale_pid_at(&pid_file)
+            .await
+            .expect("fix stale pid");
+        assert!(fixed.is_some());
+        assert!(!pid_file.exists());
     }
 }

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -4,7 +4,7 @@ use crate::service::{process, ServiceManager, ServiceStatus};
 use crate::version::VersionManager;
 use serde::Serialize;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -575,7 +575,7 @@ async fn check_stale_pid() -> DoctorCheckResult {
     check_stale_pid_at(&pid_file).await
 }
 
-async fn check_stale_pid_at(pid_file: &PathBuf) -> DoctorCheckResult {
+async fn check_stale_pid_at(pid_file: &Path) -> DoctorCheckResult {
     if !pid_file.exists() {
         return pass_result(
             "service.stale_pid",
@@ -585,7 +585,7 @@ async fn check_stale_pid_at(pid_file: &PathBuf) -> DoctorCheckResult {
         );
     }
 
-    match process::read_pid_record(&pid_file).await {
+    match process::read_pid_record(pid_file).await {
         Ok(record) => {
             if process::is_process_alive_checked(record.pid, record.start_time) {
                 pass_result(
@@ -742,12 +742,12 @@ async fn fix_stale_pid() -> anyhow::Result<Option<DoctorFixAction>> {
     fix_stale_pid_at(&pid_file).await
 }
 
-async fn fix_stale_pid_at(pid_file: &PathBuf) -> anyhow::Result<Option<DoctorFixAction>> {
+async fn fix_stale_pid_at(pid_file: &Path) -> anyhow::Result<Option<DoctorFixAction>> {
     if !pid_file.exists() {
         return Ok(None);
     }
 
-    let should_remove = match process::read_pid_record(&pid_file).await {
+    let should_remove = match process::read_pid_record(pid_file).await {
         Ok(record) => !process::is_process_alive_checked(record.pid, record.start_time),
         Err(_) => true,
     };
@@ -756,7 +756,7 @@ async fn fix_stale_pid_at(pid_file: &PathBuf) -> anyhow::Result<Option<DoctorFix
         return Ok(None);
     }
 
-    process::remove_pid_file(&pid_file).await?;
+    process::remove_pid_file(pid_file).await?;
     Ok(Some(DoctorFixAction {
         id: "service.stale_pid".to_string(),
         summary: format!("Removed stale pid file '{}'", pid_file.display()),

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1,0 +1,825 @@
+use crate::config::ConfigManager;
+use crate::core::{get_home_dir, MihomoClient, MihomoError};
+use crate::service::{ServiceManager, ServiceStatus};
+use crate::version::VersionManager;
+use serde::Serialize;
+use std::fmt;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorStatus {
+    Pass,
+    Warn,
+    Fail,
+    Skip,
+}
+
+impl DoctorStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+            Self::Skip => "SKIP",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorCheckResult {
+    pub id: String,
+    pub category: String,
+    pub status: DoctorStatus,
+    pub summary: String,
+    pub detail: Option<String>,
+    pub hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorReport {
+    pub started_at_unix: u64,
+    pub finished_at_unix: u64,
+    pub checks: Vec<DoctorCheckResult>,
+}
+
+impl DoctorReport {
+    pub fn has_failures(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.status == DoctorStatus::Fail)
+    }
+
+    pub fn count_by_status(&self, status: DoctorStatus) -> usize {
+        self.checks
+            .iter()
+            .filter(|check| check.status == status)
+            .count()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DoctorRunOptions {
+    pub only: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DoctorCheckMeta {
+    pub id: &'static str,
+    pub category: &'static str,
+    pub summary: &'static str,
+    pub why: &'static str,
+    pub fail_means: &'static str,
+    pub hint: &'static str,
+    pub fixable: bool,
+    pub default_enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DoctorExplain {
+    pub id: &'static str,
+    pub category: &'static str,
+    pub summary: &'static str,
+    pub why: &'static str,
+    pub fail_means: &'static str,
+    pub hint: &'static str,
+    pub fixable: bool,
+    pub default_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorFixAction {
+    pub id: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorFixReport {
+    pub fixes: Vec<DoctorFixAction>,
+}
+
+impl fmt::Display for DoctorCheckMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.id)
+    }
+}
+
+const CHECKS: &[DoctorCheckMeta] = &[
+    DoctorCheckMeta {
+        id: "config.settings_parse",
+        category: "config",
+        summary: "config.toml parses cleanly",
+        why: "Doctor should flag broken app-level settings before other checks derive paths from them.",
+        fail_means: "The app settings file exists but cannot be parsed as TOML.",
+        hint: "Fix the TOML syntax in config.toml or remove the broken fields.",
+        fixable: false,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "config.configs_dir",
+        category: "config",
+        summary: "resolved configs directory is understandable",
+        why: "Users need to know which configs directory is active and whether it comes from env, config.toml, or default home.",
+        fail_means: "The active configs directory cannot be resolved.",
+        hint: "Check MIHOMO_CONFIGS_DIR and [paths].configs_dir for empty or invalid paths.",
+        fixable: true,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "config.current_profile",
+        category: "config",
+        summary: "current profile name and file resolve cleanly",
+        why: "Most commands depend on the current profile and its YAML path.",
+        fail_means: "The selected profile is invalid or its resolved path cannot be constructed.",
+        hint: "Set a valid default.profile in config.toml or switch to a valid profile name.",
+        fixable: false,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "config.current_yaml",
+        category: "config",
+        summary: "current config YAML exists and parses",
+        why: "Runtime operations depend on the current config file being present and valid YAML.",
+        fail_means: "The current profile YAML is missing or invalid.",
+        hint: "Create the current profile config or fix its YAML syntax.",
+        fixable: true,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "version.binary_available",
+        category: "version",
+        summary: "default mihomo binary is available",
+        why: "Service lifecycle commands require a resolved default binary.",
+        fail_means: "No default version is configured or its binary does not exist.",
+        hint: "Install a version and set it as default with version use.",
+        fixable: false,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "service.pid_state",
+        category: "service",
+        summary: "service PID record is consistent",
+        why: "Stale PID files make lifecycle diagnostics confusing.",
+        fail_means: "The service state check itself failed unexpectedly.",
+        hint: "If the service is stopped but the pid file keeps reappearing, inspect the app home directory.",
+        fixable: false,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "controller.external_controller",
+        category: "controller",
+        summary: "external-controller resolves to a usable URL",
+        why: "Proxy, telemetry, and connection features rely on a valid controller endpoint.",
+        fail_means: "The current config cannot provide a valid external-controller value.",
+        hint: "Set external-controller to host:port, http(s)://host:port, or a unix socket path.",
+        fixable: true,
+        default_enabled: true,
+    },
+    DoctorCheckMeta {
+        id: "controller.api_reachable",
+        category: "controller",
+        summary: "controller API responds when service is running",
+        why: "Connection, proxy, and telemetry features depend on the controller being reachable.",
+        fail_means: "The service is running but the current controller endpoint does not respond.",
+        hint: "Check the external-controller value and whether the running mihomo instance is healthy.",
+        fixable: false,
+        default_enabled: true,
+    },
+];
+
+pub fn list_checks() -> &'static [DoctorCheckMeta] {
+    CHECKS
+}
+
+pub fn explain_check(check_id: &str) -> anyhow::Result<DoctorExplain> {
+    let check = CHECKS
+        .iter()
+        .find(|check| check.id == check_id)
+        .ok_or_else(|| anyhow::anyhow!("unknown doctor check '{}'", check_id))?;
+
+    Ok(DoctorExplain {
+        id: check.id,
+        category: check.category,
+        summary: check.summary,
+        why: check.why,
+        fail_means: check.fail_means,
+        hint: check.hint,
+        fixable: check.fixable,
+        default_enabled: check.default_enabled,
+    })
+}
+
+pub async fn run_doctor(options: DoctorRunOptions) -> DoctorReport {
+    let started_at_unix = unix_ts();
+    let filter = CheckFilter::parse(options.only.as_deref());
+    let mut checks = Vec::new();
+
+    if filter.matches("config.settings_parse", "config") {
+        checks.push(check_settings_parse().await);
+    }
+    if filter.matches("config.configs_dir", "config") {
+        checks.push(check_configs_dir().await);
+    }
+    if filter.matches("config.current_profile", "config") {
+        checks.push(check_current_profile().await);
+    }
+    if filter.matches("config.current_yaml", "config") {
+        checks.push(check_current_yaml().await);
+    }
+    if filter.matches("version.binary_available", "version") {
+        checks.push(check_binary_available().await);
+    }
+    if filter.matches("service.pid_state", "service") {
+        checks.push(check_service_pid_state().await);
+    }
+    if filter.matches("controller.external_controller", "controller") {
+        checks.push(check_external_controller().await);
+    }
+    if filter.matches("controller.api_reachable", "controller") {
+        checks.push(check_controller_api_reachable().await);
+    }
+
+    DoctorReport {
+        started_at_unix,
+        finished_at_unix: unix_ts(),
+        checks,
+    }
+}
+
+pub async fn fix_doctor(options: DoctorRunOptions) -> anyhow::Result<DoctorFixReport> {
+    let filter = CheckFilter::parse(options.only.as_deref());
+    let mut fixes = Vec::new();
+
+    if filter.matches("config.configs_dir", "config") {
+        if let Some(fix) = fix_configs_dir().await? {
+            fixes.push(fix);
+        }
+    }
+    if filter.matches("config.current_yaml", "config") {
+        if let Some(fix) = fix_current_yaml().await? {
+            fixes.push(fix);
+        }
+    }
+    if filter.matches("controller.external_controller", "controller") {
+        if let Some(fix) = fix_external_controller().await? {
+            fixes.push(fix);
+        }
+    }
+
+    Ok(DoctorFixReport { fixes })
+}
+
+#[derive(Debug, Default)]
+struct CheckFilter {
+    tokens: Vec<String>,
+}
+
+impl CheckFilter {
+    fn parse(raw: Option<&str>) -> Self {
+        let tokens = raw
+            .unwrap_or_default()
+            .split(',')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(|part| part.to_string())
+            .collect();
+        Self { tokens }
+    }
+
+    fn matches(&self, id: &str, category: &str) -> bool {
+        self.tokens.is_empty()
+            || self
+                .tokens
+                .iter()
+                .any(|token| token == id || token == category)
+    }
+}
+
+async fn check_settings_parse() -> DoctorCheckResult {
+    let manager = match ConfigManager::new() {
+        Ok(manager) => manager,
+        Err(err) => return fail_result("config.settings_parse", "config", err.to_string(), None),
+    };
+
+    let settings_file = home_settings_path(&manager);
+    if !settings_file.exists() {
+        return pass_result(
+            "config.settings_parse",
+            "config",
+            "config.toml not found; defaults will be used",
+            None,
+        );
+    }
+
+    match tokio::fs::read_to_string(&settings_file).await {
+        Ok(content) => match toml::from_str::<toml::Value>(&content) {
+            Ok(_) => pass_result(
+                "config.settings_parse",
+                "config",
+                &format!("Parsed '{}'", settings_file.display()),
+                None,
+            ),
+            Err(err) => fail_result(
+                "config.settings_parse",
+                "config",
+                format!("Invalid config.toml: {}", err),
+                Some("Fix the TOML syntax in config.toml."),
+            ),
+        },
+        Err(err) => fail_result(
+            "config.settings_parse",
+            "config",
+            format!("Failed to read '{}': {}", settings_file.display(), err),
+            None,
+        ),
+    }
+}
+
+async fn check_configs_dir() -> DoctorCheckResult {
+    let manager = match ConfigManager::new() {
+        Ok(manager) => manager,
+        Err(err) => return fail_result("config.configs_dir", "config", err.to_string(), None),
+    };
+
+    match manager.get_config_dir_info() {
+        Ok(info) => {
+            if info.path.is_dir() {
+                pass_result(
+                    "config.configs_dir",
+                    "config",
+                    &format!(
+                        "Using '{}' from {}",
+                        info.path.display(),
+                        info.source.as_str()
+                    ),
+                    None,
+                )
+            } else {
+                let reason = if info.path.exists() {
+                    "exists but is not a directory"
+                } else {
+                    "does not exist yet"
+                };
+                warn_result(
+                    "config.configs_dir",
+                    "config",
+                    &format!(
+                        "Resolved configs directory '{}' from {} {}",
+                        info.path.display(),
+                        info.source.as_str(),
+                        reason
+                    ),
+                    Some("Run doctor fix --only config.configs_dir to create it."),
+                )
+            }
+        }
+        Err(err) => fail_result(
+            "config.configs_dir",
+            "config",
+            format!("Cannot resolve configs directory: {}", err),
+            Some("Check MIHOMO_CONFIGS_DIR and [paths].configs_dir."),
+        ),
+    }
+}
+
+async fn check_current_profile() -> DoctorCheckResult {
+    let manager = match ConfigManager::new() {
+        Ok(manager) => manager,
+        Err(err) => return fail_result("config.current_profile", "config", err.to_string(), None),
+    };
+
+    match manager.get_current().await {
+        Ok(profile) => match manager.get_current_path().await {
+            Ok(path) => pass_result(
+                "config.current_profile",
+                "config",
+                &format!(
+                    "Current profile '{}' resolves to '{}'",
+                    profile,
+                    path.display()
+                ),
+                None,
+            ),
+            Err(err) => fail_result(
+                "config.current_profile",
+                "config",
+                format!("Current profile '{}' is unusable: {}", profile, err),
+                None,
+            ),
+        },
+        Err(err) => fail_result(
+            "config.current_profile",
+            "config",
+            format!("Cannot determine current profile: {}", err),
+            None,
+        ),
+    }
+}
+
+async fn check_current_yaml() -> DoctorCheckResult {
+    let manager = match ConfigManager::new() {
+        Ok(manager) => manager,
+        Err(err) => return fail_result("config.current_yaml", "config", err.to_string(), None),
+    };
+
+    let path = match manager.get_current_path().await {
+        Ok(path) => path,
+        Err(err) => {
+            return skip_result(
+                "config.current_yaml",
+                "config",
+                &format!(
+                    "Skipped because current profile path is unavailable: {}",
+                    err
+                ),
+            );
+        }
+    };
+
+    if !path.exists() {
+        return fail_result(
+            "config.current_yaml",
+            "config",
+            format!("Current config '{}' does not exist", path.display()),
+            Some("Run config show/current or create the current profile YAML."),
+        );
+    }
+
+    match tokio::fs::read_to_string(&path).await {
+        Ok(content) => match serde_yaml::from_str::<serde_yaml::Value>(&content) {
+            Ok(_) => pass_result(
+                "config.current_yaml",
+                "config",
+                &format!("Parsed '{}'", path.display()),
+                None,
+            ),
+            Err(err) => fail_result(
+                "config.current_yaml",
+                "config",
+                format!("Invalid YAML in '{}': {}", path.display(), err),
+                Some("Fix the YAML syntax in the current profile file."),
+            ),
+        },
+        Err(err) => fail_result(
+            "config.current_yaml",
+            "config",
+            format!("Failed to read '{}': {}", path.display(), err),
+            None,
+        ),
+    }
+}
+
+async fn check_binary_available() -> DoctorCheckResult {
+    let manager = match VersionManager::new() {
+        Ok(manager) => manager,
+        Err(err) => {
+            return fail_result("version.binary_available", "version", err.to_string(), None);
+        }
+    };
+
+    match manager.get_binary_path(None).await {
+        Ok(path) => pass_result(
+            "version.binary_available",
+            "version",
+            &format!("Default binary found at '{}'", path.display()),
+            None,
+        ),
+        Err(err) => fail_result(
+            "version.binary_available",
+            "version",
+            format!("Default binary unavailable: {}", err),
+            Some("Install a version and set it as default."),
+        ),
+    }
+}
+
+async fn check_service_pid_state() -> DoctorCheckResult {
+    let service = ServiceManager::new(PathBuf::from("mihomo"), PathBuf::from("config.yaml"));
+    match service.status().await {
+        Ok(ServiceStatus::Running(pid)) => pass_result(
+            "service.pid_state",
+            "service",
+            &format!("Service PID record is healthy (running pid {})", pid),
+            None,
+        ),
+        Ok(ServiceStatus::Stopped) => pass_result(
+            "service.pid_state",
+            "service",
+            "Service is stopped and PID state is clean",
+            None,
+        ),
+        Err(err) => fail_result(
+            "service.pid_state",
+            "service",
+            format!("Service PID state check failed: {}", err),
+            None,
+        ),
+    }
+}
+
+async fn check_external_controller() -> DoctorCheckResult {
+    let manager = match ConfigManager::new() {
+        Ok(manager) => manager,
+        Err(err) => {
+            return fail_result(
+                "controller.external_controller",
+                "controller",
+                err.to_string(),
+                None,
+            );
+        }
+    };
+
+    match manager.get_external_controller().await {
+        Ok(url) => pass_result(
+            "controller.external_controller",
+            "controller",
+            &format!("Current external-controller resolves to '{}'", url),
+            None,
+        ),
+        Err(MihomoError::NotFound(err)) => skip_result(
+            "controller.external_controller",
+            "controller",
+            &format!("Skipped because current config is missing: {}", err),
+        ),
+        Err(err) => fail_result(
+            "controller.external_controller",
+            "controller",
+            format!("Invalid external-controller: {}", err),
+            Some("Set external-controller to a valid TCP URL or unix socket path."),
+        ),
+    }
+}
+
+async fn check_controller_api_reachable() -> DoctorCheckResult {
+    match current_service_status().await {
+        Ok(ServiceStatus::Stopped) => {
+            return skip_result(
+                "controller.api_reachable",
+                "controller",
+                "Skipped because service is not running",
+            );
+        }
+        Ok(ServiceStatus::Running(_)) => {}
+        Err(err) => {
+            return fail_result(
+                "controller.api_reachable",
+                "controller",
+                format!("Unable to determine service state: {}", err),
+                None,
+            );
+        }
+    }
+
+    let manager = match ConfigManager::new() {
+        Ok(manager) => manager,
+        Err(err) => {
+            return fail_result(
+                "controller.api_reachable",
+                "controller",
+                format!("Cannot create ConfigManager: {}", err),
+                None,
+            );
+        }
+    };
+
+    let url = match manager.get_external_controller().await {
+        Ok(url) => url,
+        Err(err) => {
+            return fail_result(
+                "controller.api_reachable",
+                "controller",
+                format!("Cannot resolve external-controller: {}", err),
+                None,
+            );
+        }
+    };
+
+    let client = match MihomoClient::new(&url, None) {
+        Ok(client) => client,
+        Err(err) => {
+            return fail_result(
+                "controller.api_reachable",
+                "controller",
+                format!("Cannot create controller client: {}", err),
+                None,
+            );
+        }
+    };
+
+    match client.get_version().await {
+        Ok(version) => pass_result(
+            "controller.api_reachable",
+            "controller",
+            &format!(
+                "Controller '{}' responded with mihomo {}",
+                url, version.version
+            ),
+            None,
+        ),
+        Err(err) => fail_result(
+            "controller.api_reachable",
+            "controller",
+            format!("Controller '{}' is unreachable: {}", url, err),
+            Some("Check whether the service and external-controller endpoint match."),
+        ),
+    }
+}
+
+async fn fix_configs_dir() -> anyhow::Result<Option<DoctorFixAction>> {
+    let manager = ConfigManager::new()?;
+    let info = manager.get_config_dir_info()?;
+    if info.path.is_dir() {
+        return Ok(None);
+    }
+    tokio::fs::create_dir_all(&info.path).await?;
+    Ok(Some(DoctorFixAction {
+        id: "config.configs_dir".to_string(),
+        summary: format!("Created configs directory '{}'", info.path.display()),
+    }))
+}
+
+async fn fix_current_yaml() -> anyhow::Result<Option<DoctorFixAction>> {
+    let manager = ConfigManager::new()?;
+    let path = manager.get_current_path().await?;
+    if path.exists() {
+        let content = tokio::fs::read_to_string(&path).await?;
+        if serde_yaml::from_str::<serde_yaml::Value>(&content).is_ok() {
+            return Ok(None);
+        }
+        anyhow::bail!(
+            "refusing to overwrite invalid current config '{}'",
+            path.display()
+        );
+    }
+    manager.ensure_default_config().await?;
+    Ok(Some(DoctorFixAction {
+        id: "config.current_yaml".to_string(),
+        summary: format!("Ensured default config exists at '{}'", path.display()),
+    }))
+}
+
+async fn fix_external_controller() -> anyhow::Result<Option<DoctorFixAction>> {
+    let manager = ConfigManager::new()?;
+    let before = manager.get_external_controller().await.ok();
+    let after = manager.ensure_external_controller().await?;
+    if before.as_deref() == Some(after.as_str()) {
+        return Ok(None);
+    }
+    Ok(Some(DoctorFixAction {
+        id: "controller.external_controller".to_string(),
+        summary: format!("Ensured external-controller resolves to '{}'", after),
+    }))
+}
+
+fn home_settings_path(manager: &ConfigManager) -> PathBuf {
+    current_home_of(manager).join("config.toml")
+}
+
+fn current_home_of(_manager: &ConfigManager) -> PathBuf {
+    get_home_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+async fn current_service_status() -> crate::core::Result<ServiceStatus> {
+    let service = ServiceManager::new(PathBuf::from("mihomo"), PathBuf::from("config.yaml"));
+    service.status().await
+}
+
+fn unix_ts() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn pass_result(id: &str, category: &str, summary: &str, hint: Option<&str>) -> DoctorCheckResult {
+    DoctorCheckResult {
+        id: id.to_string(),
+        category: category.to_string(),
+        status: DoctorStatus::Pass,
+        summary: summary.to_string(),
+        detail: None,
+        hint: hint.map(|value| value.to_string()),
+    }
+}
+
+fn skip_result(id: &str, category: &str, summary: &str) -> DoctorCheckResult {
+    DoctorCheckResult {
+        id: id.to_string(),
+        category: category.to_string(),
+        status: DoctorStatus::Skip,
+        summary: summary.to_string(),
+        detail: None,
+        hint: None,
+    }
+}
+
+fn warn_result(id: &str, category: &str, summary: &str, hint: Option<&str>) -> DoctorCheckResult {
+    DoctorCheckResult {
+        id: id.to_string(),
+        category: category.to_string(),
+        status: DoctorStatus::Warn,
+        summary: summary.to_string(),
+        detail: None,
+        hint: hint.map(|value| value.to_string()),
+    }
+}
+
+fn fail_result(id: &str, category: &str, summary: String, hint: Option<&str>) -> DoctorCheckResult {
+    DoctorCheckResult {
+        id: id.to_string(),
+        category: category.to_string(),
+        status: DoctorStatus::Fail,
+        summary,
+        detail: None,
+        hint: hint.map(|value| value.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        explain_check, fix_doctor, list_checks, run_doctor, DoctorRunOptions, DoctorStatus,
+    };
+
+    #[test]
+    fn explain_known_check() {
+        let explain = explain_check("config.current_yaml").expect("explain current yaml");
+        assert_eq!(explain.category, "config");
+        assert!(explain.summary.contains("current config YAML"));
+        assert!(explain.fixable);
+    }
+
+    #[test]
+    fn list_contains_default_checks() {
+        let checks = list_checks();
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "config.settings_parse"));
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "version.binary_available"));
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "controller.api_reachable"));
+    }
+
+    #[tokio::test]
+    async fn doctor_filter_matches_category_or_id() {
+        let report = run_doctor(DoctorRunOptions {
+            only: Some("version.binary_available,service".to_string()),
+        })
+        .await;
+
+        assert_eq!(report.checks.len(), 2);
+        assert!(report
+            .checks
+            .iter()
+            .any(|check| check.id == "version.binary_available"));
+        assert!(report
+            .checks
+            .iter()
+            .any(|check| check.id == "service.pid_state"));
+    }
+
+    #[test]
+    fn report_counts_statuses() {
+        let report = super::DoctorReport {
+            started_at_unix: 1,
+            finished_at_unix: 2,
+            checks: vec![
+                super::DoctorCheckResult {
+                    id: "a".to_string(),
+                    category: "config".to_string(),
+                    status: DoctorStatus::Pass,
+                    summary: "ok".to_string(),
+                    detail: None,
+                    hint: None,
+                },
+                super::DoctorCheckResult {
+                    id: "b".to_string(),
+                    category: "config".to_string(),
+                    status: DoctorStatus::Fail,
+                    summary: "bad".to_string(),
+                    detail: None,
+                    hint: None,
+                },
+            ],
+        };
+
+        assert_eq!(report.count_by_status(DoctorStatus::Pass), 1);
+        assert_eq!(report.count_by_status(DoctorStatus::Fail), 1);
+        assert!(report.has_failures());
+    }
+
+    #[tokio::test]
+    async fn doctor_fix_empty_filter_is_safe() {
+        let report = fix_doctor(DoctorRunOptions {
+            only: Some("version".to_string()),
+        })
+        .await
+        .expect("fix doctor");
+        assert!(report.fixes.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 pub mod config;
 pub mod connection;
 pub mod core;
+pub mod doctor;
 pub mod proxy;
 pub mod service;
 pub mod version;
@@ -9,6 +10,9 @@ pub mod version;
 pub use config::{ConfigDirInfo, ConfigDirSource, ConfigManager, Profile};
 pub use connection::ConnectionManager;
 pub use core::{MihomoClient, MihomoError, Result};
+pub use doctor::{
+    DoctorCheckResult, DoctorExplain, DoctorFixAction, DoctorFixReport, DoctorReport, DoctorStatus,
+};
 pub use proxy::ProxyManager;
 pub use service::{ServiceManager, ServiceStatus};
 pub use version::{Channel, VersionManager};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,26 @@
 use clap::Parser;
-use mihomo_rs::cli::{format_cli_error, print_error, run_cli_command, Cli};
+use mihomo_rs::cli::{format_cli_error, print_error, run_cli_command_with_exit, Cli, Commands};
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = run().await {
-        print_error(&format_cli_error(&e));
-        std::process::exit(1);
+    match run().await {
+        Ok(code) => {
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
+        Err((is_doctor, error)) => {
+            print_error(&format_cli_error(&error));
+            let code = if is_doctor { 2 } else { 1 };
+            std::process::exit(code);
+        }
     }
 }
 
-async fn run() -> anyhow::Result<()> {
+async fn run() -> Result<i32, (bool, anyhow::Error)> {
     let cli = Cli::parse();
+    let is_doctor = matches!(&cli.command, Commands::Doctor { .. });
+    let command = cli.command;
 
     env_logger::Builder::from_default_env()
         .filter_level(if cli.verbose {
@@ -20,5 +30,7 @@ async fn run() -> anyhow::Result<()> {
         })
         .init();
 
-    run_cli_command(cli.command).await
+    run_cli_command_with_exit(command)
+        .await
+        .map_err(|error| (is_doctor, error))
 }

--- a/tests/cli_handlers_spec.rs
+++ b/tests/cli_handlers_spec.rs
@@ -3,9 +3,10 @@
 mod common;
 
 use mihomo_rs::cli::{
-    run_cli_command, Commands, ConfigAction, ConnectionAction, ProxyAction, ServiceAction,
-    VersionAction,
+    run_cli_command, run_cli_command_with_exit, Commands, ConfigAction, ConnectionAction,
+    DoctorAction, ProxyAction, ServiceAction, VersionAction,
 };
+use mihomo_rs::service::process;
 use mihomo_rs::{ConfigManager, VersionManager};
 use mockito::{Matcher, Server};
 use std::env;
@@ -245,6 +246,92 @@ async fn run_cli_command_covers_config_version_and_service_paths() {
 
     // Keep one direct manager call to exercise constructor path in this test context.
     let _vm = VersionManager::new().expect("version manager new");
+
+    if let Some(value) = old_home {
+        env::set_var("MIHOMO_HOME", value);
+    } else {
+        env::remove_var("MIHOMO_HOME");
+    }
+}
+
+#[tokio::test]
+async fn run_cli_command_covers_doctor_paths() {
+    let _guard = env_lock().lock().await;
+
+    let temp = tempdir().expect("create temp dir");
+    let old_home = env::var("MIHOMO_HOME").ok();
+    env::set_var("MIHOMO_HOME", temp.path());
+
+    let cm = ConfigManager::new().expect("config manager");
+    cm.save(
+        "default",
+        "port: 7890\nexternal-controller: 127.0.0.1:9090\n",
+    )
+    .await
+    .expect("write default profile");
+
+    common::install_fake_version(temp.path(), "v1.2.3").await;
+    let vm = VersionManager::new().expect("version manager");
+    vm.set_default("v1.2.3").await.expect("set default version");
+
+    run_cli_command(Commands::Doctor {
+        action: DoctorAction::List,
+    })
+    .await
+    .expect("doctor list");
+
+    run_cli_command(Commands::Doctor {
+        action: DoctorAction::Explain {
+            check_id: "service.stale_pid".to_string(),
+        },
+    })
+    .await
+    .expect("doctor explain");
+
+    let config_exit = run_cli_command_with_exit(Commands::Doctor {
+        action: DoctorAction::Run {
+            only: Some("config".to_string()),
+            json: true,
+        },
+    })
+    .await
+    .expect("doctor run config");
+    assert_eq!(config_exit, 0);
+
+    let pid_file = temp.path().join("mihomo.pid");
+    process::write_pid_record(&pid_file, u32::MAX, Some(1))
+        .await
+        .expect("write stale pid");
+
+    let stale_pid_exit = run_cli_command_with_exit(Commands::Doctor {
+        action: DoctorAction::Run {
+            only: Some("service.stale_pid".to_string()),
+            json: false,
+        },
+    })
+    .await
+    .expect("doctor run stale pid");
+    assert_eq!(stale_pid_exit, 0);
+
+    run_cli_command(Commands::Doctor {
+        action: DoctorAction::Fix {
+            only: Some("service.stale_pid".to_string()),
+            json: true,
+        },
+    })
+    .await
+    .expect("doctor fix stale pid");
+    assert!(!pid_file.exists());
+
+    let no_fix_exit = run_cli_command_with_exit(Commands::Doctor {
+        action: DoctorAction::Fix {
+            only: Some("version".to_string()),
+            json: false,
+        },
+    })
+    .await
+    .expect("doctor fix no-op");
+    assert_eq!(no_fix_exit, 0);
 
     if let Some(value) = old_home {
         env::set_var("MIHOMO_HOME", value);


### PR DESCRIPTION
## Summary
- add doctor run/list/explain commands with JSON report support
- add safe doctor fix support for config dirs, missing configs, external-controller, and stale pid files
- refine doctor exit codes and document usage in English and Chinese READMEs

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings