### PR TITLE
ci: publish Homebrew tap formula

### DIFF
--- a/.github/scripts/generate-homebrew-formula.sh
+++ b/.github/scripts/generate-homebrew-formula.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <owner/repo> <tag> <formula-path>" >&2
+  exit 1
+fi
+
+repo="$1"
+tag="$2"
+formula_path="$3"
+version="${tag#v}"
+base_url="https://github.com/${repo}/releases/download/${tag}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fetch_sha() {
+  local asset="$1"
+  curl -fsSL "${base_url}/${asset}.sha256" | awk '{print $1}'
+}
+
+darwin_amd64_sha="$(fetch_sha "mihomo-rs-darwin-amd64.tar.gz")"
+darwin_arm64_sha="$(fetch_sha "mihomo-rs-darwin-arm64.tar.gz")"
+linux_amd64_sha="$(fetch_sha "mihomo-rs-linux-amd64.tar.gz")"
+linux_arm64_sha="$(fetch_sha "mihomo-rs-linux-arm64.tar.gz")"
+
+mkdir -p "$(dirname "${formula_path}")"
+
+cat > "${formula_path}" <<EOF
+class MihomoRs < Formula
+  desc "Rust SDK and CLI tool for mihomo proxy management"
+  homepage "https://github.com/${repo}"
+  version "${version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${base_url}/mihomo-rs-darwin-arm64.tar.gz"
+      sha256 "${darwin_arm64_sha}"
+    else
+      url "${base_url}/mihomo-rs-darwin-amd64.tar.gz"
+      sha256 "${darwin_amd64_sha}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "${base_url}/mihomo-rs-linux-arm64.tar.gz"
+      sha256 "${linux_arm64_sha}"
+    else
+      url "${base_url}/mihomo-rs-linux-amd64.tar.gz"
+      sha256 "${linux_amd64_sha}"
+    end
+  end
+
+  livecheck do
+    url :stable
+    regex(/^v?(\\d+(?:\\.\\d+)+)$/i)
+  end
+
+  def install
+    bin.install "mihomo-rs"
+  end
+
+  test do
+    assert_match "mihomo-rs", shell_output("#{bin}/mihomo-rs --help")
+  end
+end
+EOF
+
+echo "Generated ${formula_path}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,3 +194,57 @@ jobs:
       - name: Publish to crates.io
         run: cargo publish --token ${{ secrets.CRATES_TOKEN }}
         continue-on-error: false
+
+  publish-homebrew-tap:
+    name: Publish Homebrew Formula
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      HOMEBREW_TAP_REPO: ${{ secrets.HOMEBREW_TAP_REPO }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - name: Check Homebrew tap settings
+        id: tap_settings
+        run: |
+          if [ -n "${HOMEBREW_TAP_REPO}" ] && [ -n "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Homebrew tap publishing skipped because HOMEBREW_TAP_REPO or HOMEBREW_TAP_TOKEN is not configured."
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.tap_settings.outputs.enabled == 'true'
+
+      - name: Checkout tap repository
+        if: steps.tap_settings.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.HOMEBREW_TAP_REPO }}
+          token: ${{ env.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Generate formula
+        if: steps.tap_settings.outputs.enabled == 'true'
+        run: |
+          chmod +x .github/scripts/generate-homebrew-formula.sh
+          .github/scripts/generate-homebrew-formula.sh \
+            "${GITHUB_REPOSITORY}" \
+            "${GITHUB_REF_NAME}" \
+            "homebrew-tap/Formula/mihomo-rs.rb"
+
+      - name: Commit and push formula update
+        if: steps.tap_settings.outputs.enabled == 'true'
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/mihomo-rs.rb
+          if git diff --cached --quiet; then
+            echo "No Homebrew formula changes to publish"
+            exit 0
+          fi
+          git commit -m "mihomo-rs ${GITHUB_REF_NAME}"
+          git push

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Rust SDK and CLI for [mihomo](https://github.com/MetaCubeX/mihomo): version inst
 cargo install mihomo-rs
 ```
 
+Homebrew:
+
+```bash
+brew tap dingdangmaoup/mihomo-rs
+brew install mihomo-rs
+
+# Global command
+mihomo-rs --help
+```
+
+Upgrade with:
+
+```bash
+brew update
+brew upgrade mihomo-rs
+```
+
 Library usage:
 
 ```toml
@@ -210,6 +227,14 @@ cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test
 ```
+
+## Release To Homebrew
+
+Tagged releases update the dedicated Homebrew tap automatically.
+
+- Release archives are published on GitHub Releases.
+- The tap repository `DINGDANGMAOUP/homebrew-mihomo-rs` stores `Formula/mihomo-rs.rb`.
+- Users upgrade with standard Homebrew flow: `brew update && brew upgrade mihomo-rs`.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ brew install mihomo-rs
 mihomo-rs --help
 ```
 
+Or install directly without a separate tap step:
+
+```bash
+brew install dingdangmaoup/mihomo-rs/mihomo-rs
+```
+
 Upgrade with:
 
 ```bash
@@ -235,6 +241,7 @@ Tagged releases update the dedicated Homebrew tap automatically.
 - Release archives are published on GitHub Releases.
 - The tap repository `DINGDANGMAOUP/homebrew-mihomo-rs` stores `Formula/mihomo-rs.rb`.
 - Users upgrade with standard Homebrew flow: `brew update && brew upgrade mihomo-rs`.
+- Tap repository: [DINGDANGMAOUP/homebrew-mihomo-rs](https://github.com/DINGDANGMAOUP/homebrew-mihomo-rs)
 
 ## Security
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,6 +30,23 @@
 cargo install mihomo-rs
 ```
 
+Homebrew：
+
+```bash
+brew tap dingdangmaoup/mihomo-rs
+brew install mihomo-rs
+
+# 全局命令
+mihomo-rs --help
+```
+
+升级：
+
+```bash
+brew update
+brew upgrade mihomo-rs
+```
+
 作为库使用：
 
 ```toml
@@ -210,6 +227,14 @@ cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test
 ```
+
+## 发布到 Homebrew
+
+打 tag 发布后，会自动更新独立的 Homebrew tap：
+
+- GitHub Releases 继续作为二进制分发源
+- tap 仓库 `DINGDANGMAOUP/homebrew-mihomo-rs` 保存 `Formula/mihomo-rs.rb`
+- 用户后续升级直接走标准 Homebrew 流程：`brew update && brew upgrade mihomo-rs`
 
 ## 安全
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -40,6 +40,12 @@ brew install mihomo-rs
 mihomo-rs --help
 ```
 
+也可以不单独执行 `tap`，直接安装：
+
+```bash
+brew install dingdangmaoup/mihomo-rs/mihomo-rs
+```
+
 升级：
 
 ```bash
@@ -235,6 +241,7 @@ cargo test
 - GitHub Releases 继续作为二进制分发源
 - tap 仓库 `DINGDANGMAOUP/homebrew-mihomo-rs` 保存 `Formula/mihomo-rs.rb`
 - 用户后续升级直接走标准 Homebrew 流程：`brew update && brew upgrade mihomo-rs`
+- tap 仓库地址：[DINGDANGMAOUP/homebrew-mihomo-rs](https://github.com/DINGDANGMAOUP/homebrew-mihomo-rs)
 
 ## 安全
 


### PR DESCRIPTION
## Summary
- add release workflow step to update the Homebrew tap formula
- add formula generation script using release checksums
- document Homebrew install and upgrade flow

## Verification
- cargo fmt --all
- bash -n .github/scripts/generate-homebrew-formula.sh
- cargo test root_help_prefers_namespaced_commands -- --nocapture
- cargo test cli_keeps_legacy_root_aliases_available -- --nocapture