### PR TITLE
release: prepare v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-rs"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mihomo-rs"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 authors = ["dingdangmaoup"]
 description = "A Rust SDK and CLI tool for mihomo proxy management with service lifecycle management, configuration handling, and real-time monitoring"


### PR DESCRIPTION
## Summary
- bump mihomo-rs version to 2.2.0
- update Cargo.lock package version

## Verification
- CI on PR #135: success
- cargo check --locked

## Release
After this PR merges to main, tag v2.2.0 from main to trigger GitHub Release, crates.io publish, and Homebrew tap update.